### PR TITLE
Add Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/AVnu/libavtp.svg?branch=master)](https://travis-ci.org/AVnu/libavtp)
+
 # About
 
 Open source implementation of Audio Video Transport Protocol (AVTP) specified


### PR DESCRIPTION
This patch adds Travis badge to README.md so build status information is
shown on libavtp's github home.