### PR TITLE
build: Add version info to library() call

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ avtp_lib = library(
 	 'src/avtp_aaf.c',
 	 'src/avtp_crf.c',
 	],
+	version: meson.project_version(),
 	include_directories: include_directories('include'),
 	install: true,
 )
@@ -26,7 +27,7 @@ pkg = import('pkgconfig')
 pkg.generate(
 	name: 'avtp',
 	description: 'AVTP packetization library',
-	version: '0.1',
+	version: meson.project_version(),
 	url: 'github.com/AVnu/OpenAvnu',
 	libraries: avtp_lib,
 )


### PR DESCRIPTION
This patch adds the version information in library() call so 'soname' is
properly set in the shared object and the standard symlinks are created
during installation.

This patch also fixes the "hard-coded" version information in
pkg.generate().

Signed-off-by: Andre Guedes <andre.guedes@intel.com>