### PR TITLE
Add __cplusplus ifguards

### DIFF
--- a/include/avtp.h
+++ b/include/avtp.h
@@ -30,6 +30,10 @@
 #include <errno.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* AVTP subtypes values. For further information refer to section 4.4.3.2 from
  * IEEE 1722-2016 spec.
  */
@@ -104,3 +108,7 @@ int avtp_pdu_get(const struct avtp_common_pdu *pdu, enum avtp_field field,
  */
 int avtp_pdu_set(struct avtp_common_pdu *pdu, enum avtp_field field,
 								uint32_t val);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/avtp_aaf.h
+++ b/include/avtp_aaf.h
@@ -30,6 +30,10 @@
 #include <errno.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* AAF PCM 'format' field values. */
 #define AVTP_AAF_FORMAT_USER			0x00
 #define AVTP_AAF_FORMAT_FLOAT_32BIT		0x01
@@ -106,3 +110,7 @@ int avtp_aaf_pdu_set(struct avtp_stream_pdu *pdu, enum avtp_aaf_field field,
  *    -EINVAL: If any argument is invalid.
  */
 int avtp_aaf_pdu_init(struct avtp_stream_pdu *pdu);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/avtp_crf.h
+++ b/include/avtp_crf.h
@@ -30,6 +30,10 @@
 #include <errno.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* CRF 'type' field values. */
 #define AVTP_CRF_TYPE_USER			0x00
 #define AVTP_CRF_TYPE_AUDIO_SAMPLE		0x01
@@ -100,3 +104,7 @@ int avtp_crf_pdu_set(struct avtp_crf_pdu *pdu, enum avtp_crf_field field,
  *    -EINVAL: If any argument is invalid.
  */
 int avtp_crf_pdu_init(struct avtp_crf_pdu *pdu);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This patch adds __cplusplus ifguards to libavtp public headers so the
library can be easily used by C++ programs.

Signed-off-by: Andre Guedes <andre.guedes@intel.com>