### PR TITLE
Fix 64bit fields handling in 32Bit environment

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#define BIT(n)				(1UL << n)
+#define BIT(n)				(1ULL << n)
 
 #define BITMASK(len)			(BIT(len) - 1)
 


### PR DESCRIPTION
This patch adds fix to handle 64bit fields of AVTPDU in 32bit environment.

AVTPDU fields are represented by bitmap and mask is used to get value from the
bits within 'bitmap'.
Current macro for shifting bits is:
	#define BIT(n)			(1UL << n)
In 32-bit system, size of the 'unsigned long' type is 32-bit while it is 64-bit
on 64-bit systems. This causes a bug when handling some CRF fields. This patch
fixes the issue by using 'unsigned long long' instead since it is 64-bit in
both 32 and 64-bit system.

Signed-off-by: Rajvi Jingar <rajvi.jingar@intel.com>