### PR TITLE
Cvf h264

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ AVTP protocol defines several AVTPDU type formats (see Table 6 from IEEE
 formarts is:
 * AAF (PCM encapsulation only)
 * CRF
+* CVF (H.264 only)
 
 # Examples
 

--- a/examples/common.c
+++ b/examples/common.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/timerfd.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "examples/common.h"
+
+#define NSEC_PER_SEC		1000000000ULL
+#define NSEC_PER_MSEC		1000000ULL
+
+int calculate_avtp_time(uint32_t *avtp_time, uint32_t max_transit_time)
+{
+	int res;
+	struct timespec tspec;
+	uint64_t ptime;
+
+	res = clock_gettime(CLOCK_REALTIME, &tspec);
+	if (res < 0) {
+		perror("Failed to get time");
+		return -1;
+	}
+
+	ptime = (tspec.tv_sec * NSEC_PER_SEC) +
+			(max_transit_time * NSEC_PER_MSEC) + tspec.tv_nsec;
+
+	*avtp_time = ptime % (1ULL << 32);
+
+	return 0;
+}
+
+int get_presentation_time(uint64_t avtp_time, struct timespec *tspec)
+{
+	int res;
+	uint64_t ptime, now;
+
+	res = clock_gettime(CLOCK_REALTIME, tspec);
+	if (res < 0) {
+		perror("Failed to get time from PHC");
+		return -1;
+	}
+
+	now = (tspec->tv_sec * NSEC_PER_SEC) + tspec->tv_nsec;
+
+	/* The avtp_timestamp within AAF packet is the lower part (32
+	 * less-significant bits) from presentation time calculated by the
+	 * talker.
+	 */
+	ptime = (now & 0xFFFFFFFF00000000ULL) | avtp_time;
+
+	/* If 'ptime' is less than the 'now', it means the higher part
+	 * from 'ptime' needs to be incremented by 1 in order to recover the
+	 * presentation time set by the talker.
+	 */
+	if (ptime < now)
+		ptime += (1ULL << 32);
+
+	tspec->tv_sec = ptime / NSEC_PER_SEC;
+	tspec->tv_nsec = ptime % NSEC_PER_SEC;
+
+	return 0;
+}
+
+int setup_socket_address(int fd, const char *ifname, uint8_t macaddr[],
+				int protocol, struct sockaddr_ll *sk_addr)
+{
+	int res;
+	struct ifreq req;
+
+	snprintf(req.ifr_name, sizeof(req.ifr_name), "%s", ifname);
+	res = ioctl(fd, SIOCGIFINDEX, &req);
+	if (res < 0) {
+		perror("Failed to get interface index");
+		return -1;
+	}
+
+	sk_addr->sll_family = AF_PACKET;
+	sk_addr->sll_protocol = htons(protocol);
+	sk_addr->sll_halen = ETH_ALEN;
+	sk_addr->sll_ifindex = req.ifr_ifindex;
+	memcpy(sk_addr->sll_addr, macaddr, ETH_ALEN);
+
+	return 0;
+}
+
+int create_talker_socket(int priority)
+{
+	int fd, res;
+
+	fd = socket(AF_PACKET, SOCK_DGRAM, htons(ETH_P_TSN));
+	if (fd < 0) {
+		perror("Failed to open socket");
+		return -1;
+	}
+
+	if (priority != -1) {
+		res = setsockopt(fd, SOL_SOCKET, SO_PRIORITY, &priority,
+							sizeof(priority));
+		if (res < 0) {
+			perror("Failed to set priority");
+			goto err;
+		}
+	}
+
+	return fd;
+
+err:
+	close(fd);
+	return -1;
+}
+
+int create_listener_socket(char *ifname, uint8_t macaddr[], int protocol)
+{
+	int fd, res;
+	struct packet_mreq mreq;
+
+	struct sockaddr_ll sk_addr;
+
+	fd = socket(AF_PACKET, SOCK_DGRAM, htons(protocol));
+	if (fd < 0) {
+		perror("Failed to open socket");
+		return -1;
+	}
+
+	res = setup_socket_address(fd, ifname, macaddr, protocol, &sk_addr);
+	if (res < 0)
+		goto err;
+
+	res = bind(fd, (struct sockaddr *) &sk_addr, sizeof(sk_addr));
+	if (res < 0) {
+		perror("Couldn't bind() to interface");
+		goto err;
+	}
+
+	mreq.mr_ifindex = sk_addr.sll_ifindex;
+	mreq.mr_type = PACKET_MR_MULTICAST;
+	mreq.mr_alen = ETH_ALEN;
+	memcpy(&mreq.mr_address, macaddr, ETH_ALEN);
+
+	res = setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP,
+					&mreq, sizeof(struct packet_mreq));
+	if (res < 0) {
+		perror("Couldn't set PACKET_ADD_MEMBERSHIP");
+		goto err;
+	}
+
+	return fd;
+
+err:
+	close(fd);
+	return -1;
+}
+
+int arm_timer(int fd, struct timespec *tspec)
+{
+	int res;
+	struct itimerspec timer_spec = { 0 };
+
+	timer_spec.it_value.tv_sec = tspec->tv_sec;
+	timer_spec.it_value.tv_nsec = tspec->tv_nsec;
+
+	res = timerfd_settime(fd, TFD_TIMER_ABSTIME, &timer_spec, NULL);
+	if (res < 0) {
+		perror("Failed to set timer");
+		return -1;
+	}
+
+	return 0;
+}
+
+int present_data(uint8_t *data, size_t len)
+{
+	ssize_t n;
+
+	n = write(STDOUT_FILENO, data, len);
+	if (n < 0 || n != len) {
+		perror("Failed to write()");
+		return -1;
+	}
+
+	return 0;
+}

--- a/examples/common.h
+++ b/examples/common.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+/* Calculate AVTP presentation time based on current time and informed
+ * max_transit_time.
+ * @avtp_time: Pointer to variable which the calculated time should be saved.
+ * @max_transit_time: Max transit time for the network
+ *
+ * Returns:
+ *    0: Success.
+ *    -1: If could not get current time.
+ */
+int calculate_avtp_time(uint32_t *avtp_time, uint32_t max_transit_time);
+
+/* Given an AVTP presentation time, retrieve correspondent time on
+ * CLOCK_REALTIME.
+ * @avtp_time: AVTP presentation time to be converted.
+ * @ts: Pointer to struct timespec where obtained time should be saved.
+ *
+ * Returns:
+ *    0: Success.
+ *    -1: If could not get CLOCK_REALTIME.
+ */
+int get_presentation_time(uint64_t avtp_time, struct timespec *tspec);
+
+/* Create TSN socket to listen for incomimg packets.
+ * @ifname: Network interface name where to create the socket.
+ * @macaddr: Stream destination MAC address.
+ * @protocol: Protocol to listen to.
+ *
+ * Returns:
+ *    >= 0: Socket file descriptor. Should be closed with close() when done.
+ *    -1: Could not create socket.
+ */
+int create_listener_socket(char *ifname, uint8_t macaddr[], int protocol);
+
+/* Create TSN socket to send packets.
+ * @priority: SO_PRIORITY to be set in socket.
+ *
+ * Returns:
+ *    >= 0: Socket file descriptor. Should be closed with close() when done.
+ *    -1: Could not create socket.
+ */
+int create_talker_socket(int priority);
+
+/* Set struct sockaddr_ll with TSN and socket parameters, so it can be used
+ * later on sendo() or bind() calls.
+ * @fd: Socket file descriptor.
+ * @ifname: Network interface name where to create the socket.
+ * @macaddr: Stream destination MAC address.
+ * @sk_addr: Pointer to struct sockaddr_ll to be set up.
+ * @protocol: Protocol used.
+ *
+ * Returns:
+ *    0: Success.
+ *    -1: Could not get interface index.
+ */
+int setup_socket_address(int fd, const char *ifname, uint8_t macaddr[],
+				int protocol, struct sockaddr_ll *sk_addr);
+
+/* Write data to standard output.
+ * @data: Data to be written.
+ * @len: Number of bytes to be written.
+ *
+ * Returns:
+ *    0: Success. It's only reported when all data is successfully written.
+ *    -1: Could not write all data.
+ */
+int present_data(uint8_t *data, size_t len);
+
+/* Arm a timerfd to go off on informed time.
+ * @fd: File descriptor of the timer.
+ * @tspec: When the time should go off.
+ *
+ * Returns:
+ *    0: Success.
+ *    -1: Could not arm timer.
+ */
+int arm_timer(int fd, struct timespec *tspec);

--- a/examples/cvf-listener.c
+++ b/examples/cvf-listener.c
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* CVF Listener example.
+ *
+ * This example implements a very simple CVF listener application which
+ * receives CVF packets from the network, retrieves video data and writes
+ * them to stdout once the presentation time is reached.
+ *
+ * For simplicity, this examples accepts only CVF H.264 packets, and the H.264
+ * data must be composed of NAL and each NAL unit can not exceed 1400 bytes.
+ *
+ * The H.264 data sent to output is in H.264 byte-stream format.
+ *
+ * TSN stream parameters such as destination mac address are passed via
+ * command-line arguments. Run 'cvf-listener --help' for more information.
+ *
+ * This example relies on the system clock to schedule video data samples for
+ * presentation. So make sure the system clock is synchronized with the PTP
+ * Hardware Clock (PHC) from your NIC and that the PHC is synchronized with
+ * the PTP time from the network. For further information on how to synchronize
+ * those clocks see ptp4l(8) and phc2sys(8) man pages.
+ *
+ * The easiest way to use this example is by combining it with a GStreamer
+ * pipeline. We use GStreamer to read the H.264 byte-stream from stdin and
+ * present it. So, to play an H.264 video from a TSN strem and show it on a X
+ * display, you can do something like:
+ *
+ * $ cvf-listener <args> | gst-launch-1.0 filesrc location=/dev/stdin \
+ *  ! decodebin ! videoconvert ! autovideosink
+ */
+
+#include <assert.h>
+#include <argp.h>
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/queue.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+#include "avtp.h"
+#include "avtp_cvf.h"
+#include "examples/common.h"
+
+#define STREAM_ID		0xAABBCCDDEEFF0001
+#define DATA_LEN		1400
+#define AVTP_H264_HEADER_LEN	(sizeof(uint32_t))
+#define AVTP_FULL_HEADER_LEN	(sizeof(struct avtp_stream_pdu) + AVTP_H264_HEADER_LEN)
+#define MAX_PDU_SIZE		(AVTP_FULL_HEADER_LEN + DATA_LEN)
+
+struct nal_entry {
+	STAILQ_ENTRY(nal_entry) entries;
+
+	uint16_t len;
+	struct timespec tspec;
+	uint8_t nal[DATA_LEN];
+};
+
+static STAILQ_HEAD(nal_queue, nal_entry) nals;
+static char ifname[IFNAMSIZ];
+static uint8_t macaddr[ETH_ALEN];
+static uint8_t expected_seq;
+
+static struct argp_option options[] = {
+	{"dst-addr", 'd', "MACADDR", 0, "Stream Destination MAC address" },
+	{"ifname", 'i', "IFNAME", 0, "Network Interface" },
+	{ 0 }
+};
+
+static error_t parser(int key, char *arg, struct argp_state *state)
+{
+	int res;
+
+	switch (key) {
+	case 'd':
+		res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+					&macaddr[0], &macaddr[1], &macaddr[2],
+					&macaddr[3], &macaddr[4], &macaddr[5]);
+		if (res != 6) {
+			fprintf(stderr, "Invalid address\n");
+			exit(EXIT_FAILURE);
+		}
+
+		break;
+	case 'i':
+		strncpy(ifname, arg, sizeof(ifname) - 1);
+		break;
+	}
+
+	return 0;
+}
+
+static struct argp argp = { options, parser };
+
+static int schedule_nal(int fd, struct timespec *tspec, uint8_t *nal,
+								ssize_t len)
+{
+	struct nal_entry *entry;
+
+	entry = malloc(sizeof(*entry));
+	if (!entry) {
+		fprintf(stderr, "Failed to allocate memory\n");
+		return -1;
+	}
+
+	entry->len = len;
+	entry->tspec.tv_sec = tspec->tv_sec;
+	entry->tspec.tv_nsec = tspec->tv_nsec;
+	memcpy(entry->nal, nal, entry->len);
+
+	STAILQ_INSERT_TAIL(&nals, entry, entries);
+
+	/* If this was the first entry inserted onto the queue, we need to arm
+	 * the timer.
+	 */
+	if (STAILQ_FIRST(&nals) == entry) {
+		int res;
+
+		res = arm_timer(fd, tspec);
+		if (res < 0) {
+			STAILQ_REMOVE(&nals, entry, nal_entry, entries);
+			free(entry);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static bool is_valid_packet(struct avtp_stream_pdu *pdu)
+{
+	struct avtp_common_pdu *common = (struct avtp_common_pdu *) pdu;
+	uint64_t val64;
+	uint32_t val32;
+	int res;
+
+	res = avtp_pdu_get(common, AVTP_FIELD_SUBTYPE, &val32);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get subtype field: %d\n", res);
+		return false;
+	}
+	if (val32 != AVTP_SUBTYPE_CVF) {
+		fprintf(stderr, "Subtype mismatch: expected %u, got %u\n",
+						AVTP_SUBTYPE_CVF, val32);
+		return false;
+	}
+
+	res = avtp_pdu_get(common, AVTP_FIELD_VERSION, &val32);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get version field: %d\n", res);
+		return false;
+	}
+	if (val32 != 0) {
+		fprintf(stderr, "Version mismatch: expected %u, got %u\n",
+								0, val32);
+		return false;
+	}
+
+	res = avtp_cvf_pdu_get(pdu, AVTP_CVF_FIELD_TV, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get tv field: %d\n", res);
+		return false;
+	}
+	if (val64 != 1) {
+		fprintf(stderr, "tv mismatch: expected %u, got %lu\n",
+								1, val64);
+		return false;
+	}
+
+	res = avtp_cvf_pdu_get(pdu, AVTP_CVF_FIELD_STREAM_ID, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get stream ID field: %d\n", res);
+		return false;
+	}
+	if (val64 != STREAM_ID) {
+		fprintf(stderr, "Stream ID mismatch: expected %lu, got %lu\n",
+							STREAM_ID, val64);
+		return false;
+	}
+
+	res = avtp_cvf_pdu_get(pdu, AVTP_CVF_FIELD_SEQ_NUM, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get sequence num field: %d\n", res);
+		return false;
+	}
+
+	if (val64 != expected_seq) {
+		/* If we have a sequence number mismatch, we simply log the
+		 * issue and continue to process the packet. We don't want to
+		 * invalidate it since it is a valid packet after all.
+		 */
+		fprintf(stderr,
+			"Sequence number mismatch: expected %u, got %lu\n",
+							expected_seq, val64);
+		expected_seq = val64;
+	}
+
+	expected_seq++;
+
+	res = avtp_cvf_pdu_get(pdu, AVTP_CVF_FIELD_FORMAT, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get format field: %d\n", res);
+		return false;
+	}
+	if (val64 != AVTP_CVF_FORMAT_RFC) {
+		fprintf(stderr, "Format mismatch: expected %u, got %lu\n",
+					AVTP_CVF_FORMAT_RFC, val64);
+		return false;
+	}
+
+	res = avtp_cvf_pdu_get(pdu, AVTP_CVF_FIELD_FORMAT_SUBTYPE, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get format subtype field: %d\n",
+									res);
+		return false;
+	}
+	if (val64 != AVTP_CVF_FORMAT_SUBTYPE_H264) {
+		fprintf(stderr, "Format mismatch: expected %u, got %lu\n",
+					AVTP_CVF_FORMAT_SUBTYPE_H264, val64);
+		return false;
+	}
+
+	return true;
+}
+
+static int get_h264_data_len(struct avtp_stream_pdu *pdu,
+						uint16_t *stream_data_len)
+{
+	int res;
+	uint64_t val;
+
+	res = avtp_cvf_pdu_get(pdu, AVTP_CVF_FIELD_STREAM_DATA_LEN, &val);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get data_len field\n");
+		return -1;
+	}
+	*stream_data_len = val - AVTP_H264_HEADER_LEN;
+
+	return 0;
+}
+
+static int new_packet(int sk_fd, int timer_fd)
+{
+	int res;
+	ssize_t n;
+	uint16_t h264_data_len;
+	uint64_t avtp_time;
+	struct timespec tspec;
+	struct avtp_stream_pdu *pdu = alloca(MAX_PDU_SIZE);
+	struct avtp_cvf_h264_payload *h264_pay =
+			(struct avtp_cvf_h264_payload *)pdu->avtp_payload;
+
+	memset(pdu, 1, MAX_PDU_SIZE);
+
+	n = recv(sk_fd, pdu, MAX_PDU_SIZE, 0);
+	if (n < 0 || n > MAX_PDU_SIZE) {
+		perror("Failed to receive data");
+		return -1;
+	}
+
+	if (!is_valid_packet(pdu)) {
+		fprintf(stderr, "Dropping packet\n");
+		return 0;
+	}
+
+	res = avtp_cvf_pdu_get(pdu, AVTP_CVF_FIELD_TIMESTAMP, &avtp_time);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get AVTP time from PDU\n");
+		return -1;
+	}
+
+	res = get_presentation_time(avtp_time, &tspec);
+	if (res < 0)
+		return -1;
+
+	res = get_h264_data_len(pdu, &h264_data_len);
+	if (res < 0)
+		return -1;
+
+	res = schedule_nal(timer_fd, &tspec, h264_pay->h264_data,
+							h264_data_len);
+	if (res < 0)
+		return -1;
+
+	return 0;
+}
+
+static int timeout(int fd)
+{
+	int res;
+	ssize_t n;
+	uint64_t expirations;
+	struct nal_entry *entry;
+
+	n = read(fd, &expirations, sizeof(uint64_t));
+	if (n < 0) {
+		perror("Failed to read timerfd");
+		return -1;
+	}
+
+	assert(expirations == 1);
+
+	entry = STAILQ_FIRST(&nals);
+	assert(entry != NULL);
+
+	res = present_data(entry->nal, entry->len);
+	if (res < 0)
+		return -1;
+
+	STAILQ_REMOVE_HEAD(&nals, entries);
+	free(entry);
+
+	if (!STAILQ_EMPTY(&nals)) {
+		entry = STAILQ_FIRST(&nals);
+
+		res = arm_timer(fd, &entry->tspec);
+		if (res < 0)
+			return -1;
+	}
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int sk_fd, timer_fd, res;
+	struct pollfd fds[2];
+
+	argp_parse(&argp, argc, argv, 0, NULL, NULL);
+
+	STAILQ_INIT(&nals);
+
+	sk_fd = create_listener_socket(ifname, macaddr, ETH_P_TSN);
+	if (sk_fd < 0)
+		return 1;
+
+	timer_fd = timerfd_create(CLOCK_REALTIME, 0);
+	if (timer_fd < 0) {
+		close(sk_fd);
+		return 1;
+	}
+
+	fds[0].fd = sk_fd;
+	fds[0].events = POLLIN;
+	fds[1].fd = timer_fd;
+	fds[1].events = POLLIN;
+
+	while (1) {
+		res = poll(fds, 2, -1);
+		if (res < 0) {
+			perror("Failed to poll() fds");
+			goto err;
+		}
+
+		if (fds[0].revents & POLLIN) {
+			res = new_packet(sk_fd, timer_fd);
+			if (res < 0)
+				goto err;
+		}
+
+		if (fds[1].revents & POLLIN) {
+			res = timeout(timer_fd);
+			if (res < 0)
+				goto err;
+		}
+	}
+
+	return 0;
+
+err:
+	close(sk_fd);
+	close(timer_fd);
+	return 1;
+}

--- a/examples/cvf-talker.c
+++ b/examples/cvf-talker.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* CVF Talker example.
+ *
+ * This example implements a very simple CVF talker application which reads
+ * an H.264 byte-stream from stdin, creates CVF packets and transmit them via
+ * network.
+ *
+ * For simplicity, this example supports only NAL units in byte-stream format,
+ * and each NAL unit can not exceed 1400 bytes.
+ *
+ * TSN stream parameters (e.g. destination mac address, traffic priority) are
+ * passed via command-line arguments. Run 'cvf-talker --help' for more
+ * information.
+ *
+ * In order to have this example working properly, make sure you have
+ * configured FQTSS feature from your NIC according (for further information
+ * see tc-cbs(8)). Also, this example relies on system clock to set the AVTP
+ * timestamp so make sure it is synchronized with the PTP Hardware Clock (PHC)
+ * from your NIC and that the PHC is synchronized with the network clock. For
+ * further information see ptp4l(8) and phc2sys(8).
+ *
+ * The easiest way to use this example is by combining it with a GStreamer
+ * pipeline. We use GStreamer to provide an H.264 stream that is sent to
+ * stdout, from where this example reads the stream. So, to generate
+ * an H.264 video to send via TSN network, you can do something like:
+ *
+ * $ gst-launch-1.0 -e -q videotestsrc pattern=ball \
+ *  ! video/x-raw,width=192,height=144 ! x264enc \
+ *  ! video/x-h264,stream-format=byte-stream ! filesink location=/dev/stdout \
+ *  | cvf-talker <args>
+ *
+ * Note that the `x264enc` may be changed by any other H.264 encoder
+ * available, as long as it generates a byte-stream with NAL units no longer
+ * than 1400 bytes.
+ */
+
+#include <alloca.h>
+#include <argp.h>
+#include <arpa/inet.h>
+#include <assert.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "avtp.h"
+#include "avtp_cvf.h"
+#include "examples/common.h"
+
+#define STREAM_ID		0xAABBCCDDEEFF0001
+#define DATA_LEN		1400
+#define AVTP_H264_HEADER_LEN	(sizeof(uint32_t))
+#define AVTP_FULL_HEADER_LEN	(sizeof(struct avtp_stream_pdu) + AVTP_H264_HEADER_LEN)
+#define MAX_PDU_SIZE		(AVTP_FULL_HEADER_LEN + DATA_LEN)
+
+static char ifname[IFNAMSIZ];
+static uint8_t macaddr[ETH_ALEN];
+static int priority = -1;
+static int max_transit_time;
+
+static char buffer[MAX_PDU_SIZE * 2];
+static size_t buffer_level;
+
+static uint8_t seq_num;
+
+enum process_result {PROCESS_OK, PROCESS_NONE, PROCESS_ERROR};
+
+static struct argp_option options[] = {
+	{"dst-addr", 'd', "MACADDR", 0, "Stream Destination MAC address" },
+	{"ifname", 'i', "IFNAME", 0, "Network Interface" },
+	{"max-transit-time", 'm', "MSEC", 0, "Maximum Transit Time in ms" },
+	{"prio", 'p', "NUM", 0, "SO_PRIORITY to be set in socket" },
+	{ 0 }
+};
+
+static error_t parser(int key, char *arg, struct argp_state *state)
+{
+	int res;
+
+	switch (key) {
+	case 'd':
+		res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+					&macaddr[0], &macaddr[1], &macaddr[2],
+					&macaddr[3], &macaddr[4], &macaddr[5]);
+		if (res != 6) {
+			fprintf(stderr, "Invalid address\n");
+			exit(EXIT_FAILURE);
+		}
+
+		break;
+	case 'i':
+		strncpy(ifname, arg, sizeof(ifname) - 1);
+		break;
+	case 'm':
+		max_transit_time = atoi(arg);
+		break;
+	case 'p':
+		priority = atoi(arg);
+		break;
+	}
+
+	return 0;
+}
+
+static struct argp argp = { options, parser };
+
+static int init_pdu(struct avtp_stream_pdu *pdu)
+{
+	int res;
+
+	res = avtp_cvf_pdu_init(pdu, AVTP_CVF_FORMAT_SUBTYPE_H264);
+	if (res < 0)
+		return -1;
+
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_TV, 1);
+	if (res < 0)
+		return -1;
+
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_STREAM_ID, STREAM_ID);
+	if (res < 0)
+		return -1;
+
+	/* Just state that all data is part of the frame (M=1) */
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_M, 1);
+	if (res < 0)
+		return -1;
+
+	/* No H.264 timestamp now */
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_H264_TIMESTAMP, 0);
+	if (res < 0)
+		return -1;
+
+	/* No H.264 timestamp means no PTV */
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_H264_PTV, 0);
+	if (res < 0)
+		return -1;
+
+	return 0;
+}
+
+static ssize_t fill_buffer(void)
+{
+	ssize_t n;
+
+	n = read(STDIN_FILENO, buffer + buffer_level,
+					sizeof(buffer) - buffer_level);
+	if (n < 0) {
+		perror("Could not read from standard input");
+	}
+
+	buffer_level += n;
+
+	return n;
+}
+
+static ssize_t start_code_position(size_t offset)
+{
+	assert(offset < buffer_level);
+
+	/* Simplified Boyer-Moore, inspired by gstreamer */
+	while (offset < buffer_level - 2) {
+		if (buffer[offset + 2] == 0x1) {
+			if (buffer[offset] == 0x0 && buffer[offset + 1] == 0x0)
+				return offset;
+			offset += 3;
+		} else if (buffer[offset + 2] == 0x0) {
+			offset++;
+		} else {
+			offset += 3;
+		}
+	}
+
+	return -1;
+}
+
+static int prepare_packet(struct avtp_stream_pdu *pdu, char *nal_data,
+							size_t nal_data_len)
+{
+	int res;
+	uint32_t avtp_time;
+	struct avtp_cvf_h264_payload *h264_pay =
+			(struct avtp_cvf_h264_payload *) pdu->avtp_payload;
+
+	res = calculate_avtp_time(&avtp_time, max_transit_time);
+	if (res < 0) {
+		fprintf(stderr, "Failed to calculate avtp time\n");
+		return -1;
+	}
+
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_TIMESTAMP,
+							avtp_time);
+	if (res < 0)
+		return -1;
+
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_SEQ_NUM, seq_num++);
+	if (res < 0)
+		return -1;
+
+	/* Stream data len includes AVTP H264 header, as this is part
+	 * of the payload too*/
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_STREAM_DATA_LEN,
+					nal_data_len + AVTP_H264_HEADER_LEN);
+	if (res < 0)
+		return -1;
+
+	memcpy(h264_pay->h264_data, nal_data, nal_data_len);
+
+	return 0;
+}
+
+static int process_nal(struct avtp_stream_pdu *pdu, bool process_last,
+							size_t *nal_len)
+{
+	int res;
+	ssize_t start, end;
+
+	*nal_len = 0;
+
+	start = start_code_position(0);
+	if (start == -1) {
+		fprintf(stderr, "Unable to find NAL start\n");
+		return PROCESS_NONE;
+	}
+	/* Now, let's find where the next starts. This is where current ends */
+	end = start_code_position(start + 1);
+	if (end == -1) {
+		if (process_last == false) {
+			return PROCESS_NONE;
+		} else {
+			end = buffer_level;
+		}
+	}
+
+	*nal_len = end - start;
+	if (*nal_len > DATA_LEN) {
+		fprintf(stderr, "NAL length bigger than expected. Expected %u, "
+					"found %zd\n", DATA_LEN, *nal_len);
+		goto err;
+	}
+
+	/* Sets AVTP packet headers and content - the NAL unit */
+	res = prepare_packet(pdu, &buffer[start], *nal_len);
+	if (res < 0) {
+		goto err;
+	}
+
+	/* Finally, let's offset any remaining data on the buffer to the
+	 * beginning. Not really efficient, but keep things simple */
+	memmove(buffer, buffer + end, buffer_level - end);
+	buffer_level -= end;
+
+	return PROCESS_OK;
+
+err:
+	return PROCESS_ERROR;
+}
+
+int main(int argc, char *argv[])
+{
+	int fd, res;
+	struct sockaddr_ll sk_addr;
+	struct avtp_stream_pdu *pdu = alloca(MAX_PDU_SIZE);
+
+	argp_parse(&argp, argc, argv, 0, NULL, NULL);
+
+	fd = create_talker_socket(priority);
+	if (fd < 0)
+		return 1;
+
+	res = setup_socket_address(fd, ifname, macaddr, ETH_P_TSN, &sk_addr);
+	if (res < 0)
+		goto err;
+
+	res = init_pdu(pdu);
+	if (res < 0)
+		goto err;
+
+	while (1) {
+		ssize_t n;
+		bool end = false;
+
+		n = fill_buffer();
+		if (n == 0)
+			end = true;
+
+		while (buffer_level > 0) {
+			enum process_result pr =
+					process_nal(pdu, end, (size_t *)&n);
+			if (pr == PROCESS_ERROR)
+				goto err;
+			if (pr == PROCESS_NONE)
+				break;
+
+			n = sendto(fd, pdu, AVTP_FULL_HEADER_LEN + n, 0,
+				(struct sockaddr *) &sk_addr, sizeof(sk_addr));
+			if (n < 0) {
+				perror("Failed to send data");
+				goto err;
+			}
+		}
+
+		if (end)
+			break;
+	}
+
+	close(fd);
+	return 0;
+
+err:
+	close(fd);
+	return 1;
+}

--- a/include/avtp_cvf.h
+++ b/include/avtp_cvf.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <errno.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* CVF 'format' field values. */
+#define AVTP_CVF_FORMAT_RFC			0x02
+
+/* CVF 'format subtype' field values. */
+#define AVTP_CVF_FORMAT_SUBTYPE_MJPEG		0x00
+#define AVTP_CVF_FORMAT_SUBTYPE_H264		0x01
+#define AVTP_CVF_FORMAT_SUBTYPE_JPEG2000	0x02
+
+enum avtp_cvf_field {
+	AVTP_CVF_FIELD_SV,
+	AVTP_CVF_FIELD_MR,
+	AVTP_CVF_FIELD_TV,
+	AVTP_CVF_FIELD_SEQ_NUM,
+	AVTP_CVF_FIELD_TU,
+	AVTP_CVF_FIELD_STREAM_ID,
+	AVTP_CVF_FIELD_TIMESTAMP,
+	AVTP_CVF_FIELD_STREAM_DATA_LEN,
+	AVTP_CVF_FIELD_FORMAT,
+	AVTP_CVF_FIELD_FORMAT_SUBTYPE,
+	AVTP_CVF_FIELD_M,
+	AVTP_CVF_FIELD_EVT,
+	AVTP_CVF_FIELD_H264_PTV,
+	AVTP_CVF_FIELD_H264_TIMESTAMP,
+	AVTP_CVF_FIELD_MAX,
+};
+
+struct avtp_cvf_h264_payload {
+	uint32_t h264_header;
+	uint8_t h264_data[0];
+} __attribute__((__packed__));
+
+/* Get value of CVF AVTPDU field.
+ * @pdu: Pointer to PDU struct.
+ * @field: PDU field to be retrieved.
+ * @val: Pointer to variable which the retrieved value should be saved.
+ *
+ * Returns:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_cvf_pdu_get(const struct avtp_stream_pdu *pdu,
+				enum avtp_cvf_field field, uint64_t *val);
+
+/* Set value of CVF AVTPDU field.
+ * @pdu: Pointer to PDU struct.
+ * @field: PDU field to be set.
+ * @val: Value to be set.
+ *
+ * Returns:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_cvf_pdu_set(struct avtp_stream_pdu *pdu, enum avtp_cvf_field field,
+								uint64_t val);
+
+/* Initialize CVF AVTPDU. All AVTPDU fields are initialized with zero except
+ * 'subtype' (which is set to AVTP_SUBTYPE_CVF), 'sv' (which is set to 1),
+ * 'format' (which is set to AVTP_CVF_FORMAT_RFC) and 'format_subtype'
+ * (which is set to the `subtype` specified).
+ * @pdu: Pointer to PDU struct.
+ * @subtype: AVTP CVF Format Subtype of this AVTPDU.
+ *
+ * Return values:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_cvf_pdu_init(struct avtp_stream_pdu *pdu, uint8_t subtype);
+
+#ifdef __cplusplus
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ avtp_lib = library(
 	 'src/avtp.c',
 	 'src/avtp_aaf.c',
 	 'src/avtp_crf.c',
+	 'src/avtp_stream.c',
 	],
 	version: meson.project_version(),
 	include_directories: include_directories('include'),
@@ -59,7 +60,18 @@ test_crf = executable(
 	build_by_default: false,
 )
 
+test_stream = executable(
+	'test-stream',
+	'unit/test-stream.c',
+	'src/avtp_stream.c',
+	include_directories: include_directories('include', 'src'),
+	link_with: avtp_lib,
+	dependencies: dependency('cmocka'),
+	build_by_default: false,
+)
+
 test('AVTP API', test_avtp)
+test('Stream API', test_stream)
 test('AAF API', test_aaf)
 test('CRF API', test_crf)
 

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ avtp_lib = library(
 	 'src/avtp.c',
 	 'src/avtp_aaf.c',
 	 'src/avtp_crf.c',
+	 'src/avtp_cvf.c',
 	 'src/avtp_stream.c',
 	],
 	version: meson.project_version(),
@@ -22,6 +23,7 @@ install_headers(
 	'include/avtp.h',
 	'include/avtp_aaf.h',
 	'include/avtp_crf.h',
+	'include/avtp_cvf.h',
 )
 
 pkg = import('pkgconfig')

--- a/meson.build
+++ b/meson.build
@@ -136,3 +136,12 @@ executable(
 	link_with: avtp_lib,
 	build_by_default: false,
 )
+
+executable(
+	'cvf-listener',
+	'examples/cvf-listener.c',
+	'examples/common.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	build_by_default: false,
+)

--- a/meson.build
+++ b/meson.build
@@ -72,10 +72,20 @@ test_stream = executable(
 	build_by_default: false,
 )
 
+test_cvf = executable(
+	'test-cvf',
+	'unit/test-cvf.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	dependencies: dependency('cmocka'),
+	build_by_default: false,
+)
+
 test('AVTP API', test_avtp)
 test('Stream API', test_stream)
 test('AAF API', test_aaf)
 test('CRF API', test_crf)
+test('CVF API', test_cvf)
 
 cc = meson.get_compiler('c')
 mdep = cc.find_library('m', required : false)

--- a/meson.build
+++ b/meson.build
@@ -93,6 +93,7 @@ mdep = cc.find_library('m', required : false)
 executable(
 	'aaf-talker',
 	'examples/aaf-talker.c',
+	'examples/common.c',
 	include_directories: include_directories('include'),
 	link_with: avtp_lib,
 	build_by_default: false,
@@ -101,6 +102,7 @@ executable(
 executable(
 	'aaf-listener',
 	'examples/aaf-listener.c',
+	'examples/common.c',
 	include_directories: include_directories('include'),
 	link_with: avtp_lib,
 	build_by_default: false,
@@ -109,6 +111,7 @@ executable(
 executable(
 	'crf-talker',
 	'examples/crf-talker.c',
+	'examples/common.c',
 	include_directories: include_directories('include'),
 	link_with: avtp_lib,
 	dependencies : mdep,
@@ -118,6 +121,7 @@ executable(
 executable(
 	'crf-listener',
 	'examples/crf-listener.c',
+	'examples/common.c',
 	include_directories: include_directories('include'),
 	link_with: avtp_lib,
 	dependencies : mdep,

--- a/meson.build
+++ b/meson.build
@@ -127,3 +127,12 @@ executable(
 	dependencies : mdep,
 	build_by_default: false,
 )
+
+executable(
+	'cvf-talker',
+	'examples/cvf-talker.c',
+	'examples/common.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	build_by_default: false,
+)

--- a/src/avtp_cvf.c
+++ b/src/avtp_cvf.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arpa/inet.h>
+#include <string.h>
+
+#include "avtp.h"
+#include "avtp_cvf.h"
+#include "avtp_stream.h"
+#include "util.h"
+
+#define SHIFT_FORMAT		(31 - 7)
+#define SHIFT_FORMAT_SUBTYPE	(31 - 15)
+#define SHIFT_M			(31 - 19)
+#define SHIFT_EVT		(31 - 23)
+#define SHIFT_PTV		(31 - 18)
+
+#define MASK_FORMAT		(BITMASK(8) << SHIFT_FORMAT)
+#define MASK_FORMAT_SUBTYPE	(BITMASK(8) << SHIFT_FORMAT_SUBTYPE)
+#define MASK_M			(BITMASK(1) << SHIFT_M)
+#define MASK_EVT		(BITMASK(4) << SHIFT_EVT)
+#define MASK_PTV		(BITMASK(1) << SHIFT_PTV)
+
+static int get_field_value(const struct avtp_stream_pdu *pdu,
+				enum avtp_cvf_field field, uint64_t *val)
+{
+	uint32_t bitmap, mask;
+	uint8_t shift;
+
+	switch (field) {
+	case AVTP_CVF_FIELD_FORMAT:
+		mask = MASK_FORMAT;
+		shift = SHIFT_FORMAT;
+		bitmap = ntohl(pdu->format_specific);
+		break;
+	case AVTP_CVF_FIELD_FORMAT_SUBTYPE:
+		mask = MASK_FORMAT_SUBTYPE;
+		shift = SHIFT_FORMAT_SUBTYPE;
+		bitmap = ntohl(pdu->format_specific);
+		break;
+	case AVTP_CVF_FIELD_M:
+		mask = MASK_M;
+		shift = SHIFT_M;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	case AVTP_CVF_FIELD_EVT:
+		mask = MASK_EVT;
+		shift = SHIFT_EVT;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	case AVTP_CVF_FIELD_H264_PTV:
+		mask = MASK_PTV;
+		shift = SHIFT_PTV;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	*val = BITMAP_GET_VALUE(bitmap, mask, shift);
+
+	return 0;
+}
+
+int avtp_cvf_pdu_get(const struct avtp_stream_pdu *pdu,
+				enum avtp_cvf_field field, uint64_t *val)
+{
+	int res;
+
+	if (!pdu || !val)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_CVF_FIELD_SV:
+	case AVTP_CVF_FIELD_MR:
+	case AVTP_CVF_FIELD_TV:
+	case AVTP_CVF_FIELD_SEQ_NUM:
+	case AVTP_CVF_FIELD_TU:
+	case AVTP_CVF_FIELD_STREAM_DATA_LEN:
+	case AVTP_CVF_FIELD_TIMESTAMP:
+	case AVTP_CVF_FIELD_STREAM_ID:
+		res = avtp_stream_pdu_get(pdu, (enum avtp_stream_field) field,
+									val);
+		break;
+	case AVTP_CVF_FIELD_FORMAT:
+	case AVTP_CVF_FIELD_FORMAT_SUBTYPE:
+	case AVTP_CVF_FIELD_M:
+	case AVTP_CVF_FIELD_EVT:
+	case AVTP_CVF_FIELD_H264_PTV:
+		res = get_field_value(pdu, field, val);
+		break;
+	case AVTP_CVF_FIELD_H264_TIMESTAMP:
+	{
+		/* This field lives on H.264 header, inside avtp_payload */
+		struct avtp_cvf_h264_payload *pay =
+			(struct avtp_cvf_h264_payload *)pdu->avtp_payload;
+		*val = ntohl(pay->h264_header);
+		res = 0;
+		break;
+	}
+	default:
+		res = -EINVAL;
+		break;
+	}
+
+	return res;
+}
+
+static int set_field_value(struct avtp_stream_pdu *pdu,
+				enum avtp_cvf_field field, uint32_t val)
+{
+	uint32_t *ptr, bitmap, mask;
+	uint8_t shift;
+
+	switch (field) {
+	case AVTP_CVF_FIELD_FORMAT:
+		mask = MASK_FORMAT;
+		shift = SHIFT_FORMAT;
+		ptr = &pdu->format_specific;
+		break;
+	case AVTP_CVF_FIELD_FORMAT_SUBTYPE:
+		mask = MASK_FORMAT_SUBTYPE;
+		shift = SHIFT_FORMAT_SUBTYPE;
+		ptr = &pdu->format_specific;
+		break;
+	case AVTP_CVF_FIELD_M:
+		mask = MASK_M;
+		shift = SHIFT_M;
+		ptr = &pdu->packet_info;
+		break;
+	case AVTP_CVF_FIELD_EVT:
+		mask = MASK_EVT;
+		shift = SHIFT_EVT;
+		ptr = &pdu->packet_info;
+		break;
+	case AVTP_CVF_FIELD_H264_PTV:
+		mask = MASK_PTV;
+		shift = SHIFT_PTV;
+		ptr = &pdu->packet_info;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	bitmap = ntohl(*ptr);
+
+	BITMAP_SET_VALUE(bitmap, val, mask, shift);
+
+	*ptr = htonl(bitmap);
+
+	return 0;
+}
+
+int avtp_cvf_pdu_set(struct avtp_stream_pdu *pdu, enum avtp_cvf_field field,
+								uint64_t val)
+{
+	int res;
+
+	if (!pdu)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_CVF_FIELD_SV:
+	case AVTP_CVF_FIELD_MR:
+	case AVTP_CVF_FIELD_TV:
+	case AVTP_CVF_FIELD_SEQ_NUM:
+	case AVTP_CVF_FIELD_TU:
+	case AVTP_CVF_FIELD_STREAM_DATA_LEN:
+	case AVTP_CVF_FIELD_TIMESTAMP:
+	case AVTP_CVF_FIELD_STREAM_ID:
+		res = avtp_stream_pdu_set(pdu, (enum avtp_stream_field) field,
+									val);
+		break;
+	case AVTP_CVF_FIELD_FORMAT:
+	case AVTP_CVF_FIELD_FORMAT_SUBTYPE:
+	case AVTP_CVF_FIELD_M:
+	case AVTP_CVF_FIELD_EVT:
+	case AVTP_CVF_FIELD_H264_PTV:
+		res = set_field_value(pdu, field, val);
+		break;
+	case AVTP_CVF_FIELD_H264_TIMESTAMP:
+	{
+		/* This field lives on H.264 header, inside avtp_payload */
+		struct avtp_cvf_h264_payload *pay =
+			(struct avtp_cvf_h264_payload *)pdu->avtp_payload;
+		pay->h264_header = htonl(val);
+		res = 0;
+		break;
+	}
+	default:
+		res = -EINVAL;
+		break;
+	}
+
+	return res;
+}
+
+int avtp_cvf_pdu_init(struct avtp_stream_pdu *pdu, uint8_t subtype)
+{
+	int res;
+
+	if (!pdu)
+		return -EINVAL;
+
+	if (subtype > AVTP_CVF_FORMAT_SUBTYPE_JPEG2000)
+		return -EINVAL;
+
+	memset(pdu, 0, sizeof(struct avtp_stream_pdu));
+
+	res = avtp_pdu_set((struct avtp_common_pdu *) pdu, AVTP_FIELD_SUBTYPE,
+							AVTP_SUBTYPE_CVF);
+	if (res < 0)
+		return res;
+
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_SV, 1);
+	if (res < 0)
+		return res;
+
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_FORMAT, AVTP_CVF_FORMAT_RFC);
+	if (res < 0)
+		return res;
+
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_FORMAT_SUBTYPE, subtype);
+	if (res < 0)
+		return res;
+
+	return 0;
+}

--- a/src/avtp_stream.c
+++ b/src/avtp_stream.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arpa/inet.h>
+#include <stddef.h>
+
+#include "avtp.h"
+#include "avtp_stream.h"
+#include "util.h"
+
+#define SHIFT_SV			(31 - 8)
+#define SHIFT_MR			(31 - 12)
+#define SHIFT_TV			(31 - 15)
+#define SHIFT_SEQ_NUM			(31 - 23)
+#define SHIFT_STREAM_DATA_LEN		(31 - 15)
+
+#define MASK_SV				(BITMASK(1) << SHIFT_SV)
+#define MASK_MR				(BITMASK(1) << SHIFT_MR)
+#define MASK_TV				(BITMASK(1) << SHIFT_TV)
+#define MASK_SEQ_NUM			(BITMASK(8) << SHIFT_SEQ_NUM)
+#define MASK_TU				(BITMASK(1))
+#define MASK_STREAM_DATA_LEN		(BITMASK(16) << SHIFT_STREAM_DATA_LEN)
+
+static int get_field_value(const struct avtp_stream_pdu *pdu,
+				enum avtp_stream_field field, uint64_t *val)
+{
+	uint32_t bitmap, mask;
+	uint8_t shift;
+
+	switch (field) {
+	case AVTP_STREAM_FIELD_SV:
+		mask = MASK_SV;
+		shift = SHIFT_SV;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_STREAM_FIELD_MR:
+		mask = MASK_MR;
+		shift = SHIFT_MR;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_STREAM_FIELD_TV:
+		mask = MASK_TV;
+		shift = SHIFT_TV;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_STREAM_FIELD_SEQ_NUM:
+		mask = MASK_SEQ_NUM;
+		shift = SHIFT_SEQ_NUM;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_STREAM_FIELD_TU:
+		mask = MASK_TU;
+		shift = 0;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_STREAM_FIELD_STREAM_DATA_LEN:
+		mask = MASK_STREAM_DATA_LEN;
+		shift = SHIFT_STREAM_DATA_LEN;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	*val = BITMAP_GET_VALUE(bitmap, mask, shift);
+
+	return 0;
+}
+
+int avtp_stream_pdu_get(const struct avtp_stream_pdu *pdu,
+				enum avtp_stream_field field, uint64_t *val)
+{
+	int res;
+
+	if (!pdu || !val)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_STREAM_FIELD_SV:
+	case AVTP_STREAM_FIELD_MR:
+	case AVTP_STREAM_FIELD_TV:
+	case AVTP_STREAM_FIELD_SEQ_NUM:
+	case AVTP_STREAM_FIELD_TU:
+	case AVTP_STREAM_FIELD_STREAM_DATA_LEN:
+		res = get_field_value(pdu, field, val);
+		break;
+	case AVTP_STREAM_FIELD_TIMESTAMP:
+		*val = ntohl(pdu->avtp_time);
+		res = 0;
+		break;
+	case AVTP_STREAM_FIELD_STREAM_ID:
+		*val = be64toh(pdu->stream_id);
+		res = 0;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return res;
+}
+
+static int set_field_value(struct avtp_stream_pdu *pdu,
+				enum avtp_stream_field field, uint64_t val)
+{
+	uint32_t *ptr, bitmap, mask;
+	uint8_t shift;
+
+	switch (field) {
+	case AVTP_STREAM_FIELD_SV:
+		mask = MASK_SV;
+		shift = SHIFT_SV;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_STREAM_FIELD_MR:
+		mask = MASK_MR;
+		shift = SHIFT_MR;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_STREAM_FIELD_TV:
+		mask = MASK_TV;
+		shift = SHIFT_TV;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_STREAM_FIELD_SEQ_NUM:
+		mask = MASK_SEQ_NUM;
+		shift = SHIFT_SEQ_NUM;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_STREAM_FIELD_TU:
+		mask = MASK_TU;
+		shift = 0;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_STREAM_FIELD_STREAM_DATA_LEN:
+		mask = MASK_STREAM_DATA_LEN;
+		shift = SHIFT_STREAM_DATA_LEN;
+		ptr = &pdu->packet_info;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	bitmap = ntohl(*ptr);
+
+	BITMAP_SET_VALUE(bitmap, val, mask, shift);
+
+	*ptr = htonl(bitmap);
+
+	return 0;
+}
+
+int avtp_stream_pdu_set(struct avtp_stream_pdu *pdu,
+				enum avtp_stream_field field, uint64_t value)
+{
+	int res;
+
+	if (!pdu)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_STREAM_FIELD_SV:
+	case AVTP_STREAM_FIELD_MR:
+	case AVTP_STREAM_FIELD_TV:
+	case AVTP_STREAM_FIELD_SEQ_NUM:
+	case AVTP_STREAM_FIELD_TU:
+	case AVTP_STREAM_FIELD_STREAM_DATA_LEN:
+		res = set_field_value(pdu, field, value);
+		break;
+	case AVTP_STREAM_FIELD_TIMESTAMP:
+		pdu->avtp_time = htonl(value);
+		res = 0;
+		break;
+	case AVTP_STREAM_FIELD_STREAM_ID:
+		pdu->stream_id = htobe64(value);
+		res = 0;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return res;
+}

--- a/src/avtp_stream.h
+++ b/src/avtp_stream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -30,54 +30,46 @@
 #include <errno.h>
 #include <stdint.h>
 
+#pragma GCC visibility push(hidden)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* AAF PCM 'format' field values. */
-#define AVTP_AAF_FORMAT_USER			0x00
-#define AVTP_AAF_FORMAT_FLOAT_32BIT		0x01
-#define AVTP_AAF_FORMAT_INT_32BIT		0x02
-#define AVTP_AAF_FORMAT_INT_24BIT		0x03
-#define AVTP_AAF_FORMAT_INT_16BIT		0x04
-#define AVTP_AAF_FORMAT_AES3_32BIT		0x05
-
-/* AAF PCM 'nsr' (nominal sample rate) field values. */
-#define AVTP_AAF_PCM_NSR_USER			0x00
-#define AVTP_AAF_PCM_NSR_8KHZ			0x01
-#define AVTP_AAF_PCM_NSR_16KHZ			0x02
-#define AVTP_AAF_PCM_NSR_32KHZ			0x03
-#define AVTP_AAF_PCM_NSR_44_1KHZ		0x04
-#define AVTP_AAF_PCM_NSR_48KHZ			0x05
-#define AVTP_AAF_PCM_NSR_88_2KHZ		0x06
-#define AVTP_AAF_PCM_NSR_96KHZ			0x07
-#define AVTP_AAF_PCM_NSR_176_4KHZ		0x08
-#define AVTP_AAF_PCM_NSR_192KHZ			0x09
-#define AVTP_AAF_PCM_NSR_24KHZ			0x0A
-
-/* AAF PCM 'sp' (sparse timestamp) field values. */
-#define AVTP_AAF_PCM_SP_NORMAL			0x00
-#define AVTP_AAF_PCM_SP_SPARSE			0x01
-
-enum avtp_aaf_field {
-	AVTP_AAF_FIELD_SV,
-	AVTP_AAF_FIELD_MR,
-	AVTP_AAF_FIELD_TV,
-	AVTP_AAF_FIELD_SEQ_NUM,
-	AVTP_AAF_FIELD_TU,
-	AVTP_AAF_FIELD_STREAM_ID,
-	AVTP_AAF_FIELD_TIMESTAMP,
-	AVTP_AAF_FIELD_STREAM_DATA_LEN,
-	AVTP_AAF_FIELD_FORMAT,
-	AVTP_AAF_FIELD_NSR,
-	AVTP_AAF_FIELD_CHAN_PER_FRAME,
-	AVTP_AAF_FIELD_BIT_DEPTH,
-	AVTP_AAF_FIELD_SP,
-	AVTP_AAF_FIELD_EVT,
-	AVTP_AAF_FIELD_MAX,
+/* XXX: To be able to use the functions provided by this header,
+ * without needing to direct "translate" enum values, it is necessary
+ * that any format specific enum have the following fields (excluding
+ * AVTP_STREAM_FIELD_MAX) in the same order as below. For instance,
+ * some `enum avtp_newformat_field` would start like:
+ *
+ * enum avtp_newformat_field {
+ *      AVTP_NEWFORMAT_FIELD_SV,
+ *      AVTP_NEWFORMAT_FIELD_MR,
+ *      // (other stream fields here)
+ *      AVTP_NEWFORMAT_FIELD_XYZ,
+ *      // (other newformat specific fields here)
+ * }
+ *
+ * This way, one can simply cast enums when calling functions from this
+ * header:
+ *
+ * avtp_stream_pdu_get(pdu, (enum avtp_stream_field) field, val);
+ *
+ * Otherwise, the mapping step would be necessary before the calls.
+ */
+enum avtp_stream_field {
+	AVTP_STREAM_FIELD_SV,
+	AVTP_STREAM_FIELD_MR,
+	AVTP_STREAM_FIELD_TV,
+	AVTP_STREAM_FIELD_SEQ_NUM,
+	AVTP_STREAM_FIELD_TU,
+	AVTP_STREAM_FIELD_STREAM_ID,
+	AVTP_STREAM_FIELD_TIMESTAMP,
+	AVTP_STREAM_FIELD_STREAM_DATA_LEN,
+	AVTP_STREAM_FIELD_MAX
 };
 
-/* Get value from AAF AVTPDU field.
+/* Get value from Stream AVTPDU field.
  * @pdu: Pointer to PDU struct.
  * @field: PDU field to be retrieved.
  * @val: Pointer to variable which the retrieved value should be saved.
@@ -86,10 +78,10 @@ enum avtp_aaf_field {
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_aaf_pdu_get(const struct avtp_stream_pdu *pdu,
-				enum avtp_aaf_field field, uint64_t *val);
+int avtp_stream_pdu_get(const struct avtp_stream_pdu *pdu,
+				enum avtp_stream_field field, uint64_t *val);
 
-/* Set value from AAF AVTPDU field.
+/* Set value from Stream AVTPDU field.
  * @pdu: Pointer to PDU struct.
  * @field: PDU field to be set.
  * @val: Value to be set.
@@ -98,19 +90,11 @@ int avtp_aaf_pdu_get(const struct avtp_stream_pdu *pdu,
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_aaf_pdu_set(struct avtp_stream_pdu *pdu, enum avtp_aaf_field field,
-								uint64_t val);
-
-/* Initialize AAF AVTPDU. All AVTPDU fields are initialized with zero except
- * 'subtype' (which is set to AVTP_SUBTYPE_AAF) and 'sv' (which is set to 1).
- * @pdu: Pointer to PDU struct.
- *
- * Return values:
- *    0: Success.
- *    -EINVAL: If any argument is invalid.
- */
-int avtp_aaf_pdu_init(struct avtp_stream_pdu *pdu);
+int avtp_stream_pdu_set(struct avtp_stream_pdu *pdu,
+				enum avtp_stream_field field, uint64_t val);
 
 #ifdef __cplusplus
 }
 #endif
+
+#pragma GCC visibility pop

--- a/travis.sh
+++ b/travis.sh
@@ -3,4 +3,4 @@ set -ev
 
 mkdir build
 CFLAGS=-Wno-missing-braces meson . build
-ninja -C build/ test aaf-talker aaf-listener crf-talker crf-listener cvf-talker
+ninja -C build/ test aaf-talker aaf-listener crf-talker crf-listener cvf-talker cvf-listener

--- a/travis.sh
+++ b/travis.sh
@@ -3,4 +3,4 @@ set -ev
 
 mkdir build
 CFLAGS=-Wno-missing-braces meson . build
-ninja -C build/ test aaf-talker aaf-listener crf-talker crf-listener
+ninja -C build/ test aaf-talker aaf-listener crf-talker crf-listener cvf-talker

--- a/unit/test-cvf.c
+++ b/unit/test-cvf.c
@@ -1,0 +1,597 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <alloca.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <arpa/inet.h>
+
+#include "avtp.h"
+#include "avtp_cvf.h"
+
+static void cvf_get_field_null_pdu(void **state)
+{
+	int res;
+	uint64_t val = 1;
+
+	res = avtp_cvf_pdu_get(NULL, AVTP_CVF_FIELD_SV, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void cvf_get_field_null_val(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_SV, NULL);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void cvf_get_field_invalid_field(void **state)
+{
+	int res;
+	uint64_t val = 1;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_MAX, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void cvf_get_field_sv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'sv' field to 1. */
+	pdu.subtype_data = htonl(0x00800000);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_SV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void cvf_get_field_mr(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'mr' field to 1. */
+	pdu.subtype_data = htonl(0x00080000);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_MR, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void cvf_get_field_tv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'tv' field to 1. */
+	pdu.subtype_data = htonl(0x00010000);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_TV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void cvf_get_field_seq_num(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'sequence_num' field to 0x55. */
+	pdu.subtype_data = htonl(0x00005500);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_SEQ_NUM, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x55);
+}
+
+static void cvf_get_field_tu(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'tu' field to 1. */
+	pdu.subtype_data = htonl(0x00000001);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_TU, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void cvf_get_field_stream_id(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'stream_id' field to 0xAABBCCDDEEFF0001. */
+	pdu.stream_id = htobe64(0xAABBCCDDEEFF0001);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_STREAM_ID, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAABBCCDDEEFF0001);
+}
+
+static void cvf_get_field_timestamp(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'avtp_timestamp' field to 0x80C0FFEE. */
+	pdu.avtp_time = htonl(0x80C0FFEE);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_TIMESTAMP, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x80C0FFEE);
+}
+
+static void cvf_get_field_format(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'format' field to AVTP_CVF_FORMAT_RFC. */
+	pdu.format_specific = htonl(0x02000000);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_FORMAT, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == AVTP_CVF_FORMAT_RFC);
+}
+
+static void cvf_get_field_format_subtype(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'format_subtype' field to AVTP_CVF_FORMAT_SUBTYPE_H264. */
+	pdu.format_specific = htonl(0x00010000);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_FORMAT_SUBTYPE, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == AVTP_CVF_FORMAT_SUBTYPE_H264);
+}
+
+static void cvf_get_field_data_len(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'stream_data_length' field to 0xAAAA. */
+	pdu.packet_info = htonl(0xAAAA0000);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_STREAM_DATA_LEN, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAAAA);
+}
+
+static void cvf_get_field_m(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'M' field to 0x1. */
+	pdu.packet_info = htonl(0x00001000);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_M, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x1);
+}
+
+static void cvf_get_field_evt(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'evt' field to 0xA. */
+	pdu.packet_info = htonl(0x00000A00);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_EVT, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xA);
+}
+
+static void cvf_set_field_null_pdu(void **state)
+{
+	int res;
+
+	res = avtp_cvf_pdu_set(NULL, AVTP_CVF_FIELD_SV, 1);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void cvf_set_field_invalid_field(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_MAX, 1);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void cvf_set_field_sv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_SV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00800000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_mr(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_MR, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00080000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_tv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_TV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00010000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_seq_num(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_SEQ_NUM, 0x55);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00005500);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_tu(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_TU, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00000001);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_stream_id(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_STREAM_ID,
+							0xAABBCCDDEEFF0001);
+
+	assert_int_equal(res, 0);
+	assert_true(be64toh(pdu.stream_id) == 0xAABBCCDDEEFF0001);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_timestamp(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_TIMESTAMP, 0x80C0FFEE);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.avtp_time) == 0x80C0FFEE);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_format(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_FORMAT,
+						AVTP_CVF_FORMAT_RFC);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.format_specific) == 0x02000000);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_format_subtype(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_FORMAT_SUBTYPE,
+						AVTP_CVF_FORMAT_SUBTYPE_H264);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.format_specific) == 0x10000);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void cvf_set_field_data_len(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_STREAM_DATA_LEN, 0xAAAA);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.packet_info) == 0xAAAA0000);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+}
+
+static void cvf_set_field_m(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_M, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.packet_info) == 0x00001000);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+}
+
+static void cvf_set_field_evt(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_EVT, 0xA);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.packet_info) == 0x00000A00);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+}
+
+static void cvf_pdu_init_null_pdu(void **state)
+{
+	int res;
+
+	res = avtp_cvf_pdu_init(NULL, AVTP_CVF_FORMAT_SUBTYPE_H264);
+	assert_int_equal(res, -EINVAL);
+}
+
+static void cvf_pdu_init_invalid_subtype(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu;
+
+	res = avtp_cvf_pdu_init(&pdu, AVTP_CVF_FORMAT_SUBTYPE_JPEG2000 + 1);
+	assert_int_equal(res, -EINVAL);
+}
+
+static void cvf_pdu_init(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu;
+
+	res = avtp_cvf_pdu_init(&pdu, AVTP_CVF_FORMAT_SUBTYPE_H264);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x03800000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(ntohl(pdu.format_specific) == 0x2010000);
+	assert_true(pdu.packet_info == 0);
+}
+
+/**** Tests for H.264 fields ****/
+
+static void cvf_get_field_h264_ptv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'ptv' field to 1. */
+	pdu.packet_info = htonl(0x00002000);
+
+	res = avtp_cvf_pdu_get(&pdu, AVTP_CVF_FIELD_H264_PTV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void cvf_get_field_h264_timestamp(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu =
+		alloca(sizeof(struct avtp_stream_pdu) + sizeof(uint32_t));
+	struct avtp_cvf_h264_payload *pay =
+			(struct avtp_cvf_h264_payload *)pdu->avtp_payload;
+
+	/* Set 'h264_timestamp' field (which lives in h264_header) to
+	 * 0x80C0FFEE. */
+	pay->h264_header = htonl(0x80C0FFEE);
+
+	res = avtp_cvf_pdu_get(pdu, AVTP_CVF_FIELD_H264_TIMESTAMP, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x80C0FFEE);
+}
+
+static void cvf_set_field_h264_ptv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_cvf_pdu_set(&pdu, AVTP_CVF_FIELD_H264_PTV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(ntohl(pdu.packet_info) == 0x00002000);
+}
+
+static void cvf_set_field_h264_timestamp(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu =
+		alloca(sizeof(struct avtp_stream_pdu) + sizeof(uint32_t));
+	struct avtp_cvf_h264_payload *pay =
+			(struct avtp_cvf_h264_payload *)pdu->avtp_payload;
+	memset(pdu, 0, sizeof(struct avtp_stream_pdu) + sizeof(uint32_t));
+
+	res = avtp_cvf_pdu_set(pdu, AVTP_CVF_FIELD_H264_TIMESTAMP, 0x80C0FFEE);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(ntohl(pay->h264_header) == 0x80C0FFEE);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(cvf_get_field_null_pdu),
+		cmocka_unit_test(cvf_get_field_null_val),
+		cmocka_unit_test(cvf_get_field_invalid_field),
+		cmocka_unit_test(cvf_get_field_sv),
+		cmocka_unit_test(cvf_get_field_mr),
+		cmocka_unit_test(cvf_get_field_tv),
+		cmocka_unit_test(cvf_get_field_seq_num),
+		cmocka_unit_test(cvf_get_field_tu),
+		cmocka_unit_test(cvf_get_field_stream_id),
+		cmocka_unit_test(cvf_get_field_timestamp),
+		cmocka_unit_test(cvf_get_field_format),
+		cmocka_unit_test(cvf_get_field_format_subtype),
+		cmocka_unit_test(cvf_get_field_data_len),
+		cmocka_unit_test(cvf_get_field_m),
+		cmocka_unit_test(cvf_get_field_evt),
+		cmocka_unit_test(cvf_get_field_h264_ptv),
+		cmocka_unit_test(cvf_get_field_h264_timestamp),
+		cmocka_unit_test(cvf_set_field_null_pdu),
+		cmocka_unit_test(cvf_set_field_invalid_field),
+		cmocka_unit_test(cvf_set_field_sv),
+		cmocka_unit_test(cvf_set_field_mr),
+		cmocka_unit_test(cvf_set_field_tv),
+		cmocka_unit_test(cvf_set_field_seq_num),
+		cmocka_unit_test(cvf_set_field_tu),
+		cmocka_unit_test(cvf_set_field_stream_id),
+		cmocka_unit_test(cvf_set_field_timestamp),
+		cmocka_unit_test(cvf_set_field_format),
+		cmocka_unit_test(cvf_set_field_format_subtype),
+		cmocka_unit_test(cvf_set_field_data_len),
+		cmocka_unit_test(cvf_set_field_m),
+		cmocka_unit_test(cvf_set_field_evt),
+		cmocka_unit_test(cvf_set_field_h264_ptv),
+		cmocka_unit_test(cvf_set_field_h264_timestamp),
+		cmocka_unit_test(cvf_pdu_init_null_pdu),
+		cmocka_unit_test(cvf_pdu_init_invalid_subtype),
+		cmocka_unit_test(cvf_pdu_init),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/unit/test-stream.c
+++ b/unit/test-stream.c
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <arpa/inet.h>
+
+#include "avtp.h"
+#include "avtp_stream.h"
+
+static void stream_get_field_null_pdu(void **state)
+{
+	int res;
+	uint64_t val;
+
+	res = avtp_stream_pdu_get(NULL, AVTP_STREAM_FIELD_SV, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void stream_get_field_null_val(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_SV, NULL);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void stream_get_field_invalid_field(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_MAX, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void stream_get_field_sv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* stream_set 'sv' field to 1. */
+	pdu.subtype_data = htonl(0x00800000);
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_SV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void stream_get_field_mr(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* stream_set 'mr' field to 1. */
+	pdu.subtype_data = htonl(0x00080000);
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_MR, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void stream_get_field_tv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* stream_set 'tv' field to 1. */
+	pdu.subtype_data = htonl(0x00010000);
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_TV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void stream_get_field_seq_num(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* stream_set 'sequence_num' field to 0x55. */
+	pdu.subtype_data = htonl(0x00005500);
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_SEQ_NUM, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x55);
+}
+
+static void stream_get_field_tu(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* stream_set 'tu' field to 1. */
+	pdu.subtype_data = htonl(0x00000001);
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_TU, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void stream_get_field_stream_id(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* stream_set 'stream_id' field to 0xAABBCCDDEEFF0001. */
+	pdu.stream_id = htobe64(0xAABBCCDDEEFF0001);
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_STREAM_ID, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAABBCCDDEEFF0001);
+}
+
+static void stream_get_field_timestamp(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* stream_set 'avtp_timestamp' field to 0x80C0FFEE. */
+	pdu.avtp_time = htonl(0x80C0FFEE);
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_TIMESTAMP, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x80C0FFEE);
+}
+
+static void stream_get_field_data_len(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* stream_set 'stream_data_length' field to 0xAAAA. */
+	pdu.packet_info = htonl(0xAAAA0000);
+
+	res = avtp_stream_pdu_get(&pdu, AVTP_STREAM_FIELD_STREAM_DATA_LEN,
+									&val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAAAA);
+}
+
+static void stream_set_field_null_pdu(void **state)
+{
+	int res;
+
+	res = avtp_stream_pdu_set(NULL, AVTP_STREAM_FIELD_SV, 0);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void stream_set_field_invalid_field(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_MAX, 1);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void stream_set_field_sv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_SV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00800000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void stream_set_field_mr(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_MR, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00080000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void stream_set_field_tv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_TV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00010000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void stream_set_field_seq_num(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_SEQ_NUM, 0x55);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00005500);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void stream_set_field_tu(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_TU, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00000001);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void stream_set_field_stream_id(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_STREAM_ID,
+							0xAABBCCDDEEFF0001);
+
+	assert_int_equal(res, 0);
+	assert_true(be64toh(pdu.stream_id) == 0xAABBCCDDEEFF0001);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void stream_set_field_timestamp(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_TIMESTAMP,
+								0x80C0FFEE);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.avtp_time) == 0x80C0FFEE);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void stream_set_field_data_len(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_stream_pdu_set(&pdu, AVTP_STREAM_FIELD_STREAM_DATA_LEN,
+									0xAAAA);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.packet_info) == 0xAAAA0000);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(stream_get_field_null_pdu),
+		cmocka_unit_test(stream_get_field_null_val),
+		cmocka_unit_test(stream_get_field_invalid_field),
+		cmocka_unit_test(stream_get_field_sv),
+		cmocka_unit_test(stream_get_field_mr),
+		cmocka_unit_test(stream_get_field_tv),
+		cmocka_unit_test(stream_get_field_seq_num),
+		cmocka_unit_test(stream_get_field_tu),
+		cmocka_unit_test(stream_get_field_stream_id),
+		cmocka_unit_test(stream_get_field_timestamp),
+		cmocka_unit_test(stream_get_field_data_len),
+		cmocka_unit_test(stream_set_field_null_pdu),
+		cmocka_unit_test(stream_set_field_invalid_field),
+		cmocka_unit_test(stream_set_field_sv),
+		cmocka_unit_test(stream_set_field_mr),
+		cmocka_unit_test(stream_set_field_tv),
+		cmocka_unit_test(stream_set_field_seq_num),
+		cmocka_unit_test(stream_set_field_tu),
+		cmocka_unit_test(stream_set_field_stream_id),
+		cmocka_unit_test(stream_set_field_timestamp),
+		cmocka_unit_test(stream_set_field_data_len),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
CVF support for libavtp

Compressed Video Format (CVF) is one of video formats defined by AVTP (IEEE 1722-2016 chapter 8). This pull request adds support to it, focusing on H.264 aspects, so fields related exclusively to MJPEG or JPEG2000 are not done in this PR.

As there is some overlapping fields on both AAF and CVF headers, the first patch in this series factor out common code in a way that no changes are done to AAF API, but enables some code reuse. Some code that is also duplicated on AAF and CVF examples prompted another patch that creates a "common" shared code for the examples, so things like socket configuration are on it.

For the sake of simplicity, this PR does not cover the "sub-packets" defined for aggregation types on AVTP. 

This PR also adds unit tests for CVF, and examples for CVF talker and listener.

More information about each patch, on the patch commit message.

Overall code coverage details are:
lines......: 97.6% (1321 of 1353 lines)
functions..: 100.0% (134 of 134 functions)

Let me know of any questions,