### PR TITLE
Iec 61883/IIDC

### DIFF
--- a/examples/ieciidc-listener.c
+++ b/examples/ieciidc-listener.c
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* IEC 61883/IIDC Listener example.
+ *
+ * This example implements a very simple IEC 61883/IIDC listener application
+ * which receives AVTP packets from the network, retrieves the MPEG-TS packets,
+ * and writes them to stdout once the presentation time is reached.
+ *
+ * For simplicity, the example supports MPEG-TS streams, and expects that each
+ * AVTP packet contains only one source packet.
+ *
+ * TSN stream parameters such as destination mac address are passed via
+ * command-line arguments. Run 'ieciidc-listener --help' for more information.
+ *
+ * This example relies on the system clock to schedule MPEG-TS packets for
+ * playback. So make sure the system clock is synchronized with the PTP
+ * Hardware Clock (PHC) from your NIC and that the PHC is synchronized with
+ * the PTP time from the network. For further information on how to synchronize
+ * those clocks see ptp4l(8) and phc2sys(8) man pages.
+ *
+ * The easiest way to use this example is by combining it with a GStreamer
+ * pipeline. We provide an MPEG-TS stream that is sent to stdout, from where
+ * GStreameer reads the stream. So, to send the MPEG-TS stream received from
+ * the TSN network to GStreamer, you can do something like:
+ *
+ * $ ieciidc-listener <args> | gst-launch-1.0 -e -q filesrc location=/dev/stdin
+ *  ! tsdemux ! decodebin ! videoconvert ! autovideosink
+ */
+
+#include <assert.h>
+#include <argp.h>
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/queue.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+#include <inttypes.h>
+
+#include "avtp.h"
+#include "avtp_ieciidc.h"
+#include "examples/common.h"
+
+#define STREAM_ID		0xAABBCCDDEEFF0001
+#define MPEG_TS_PACKET_LEN	188
+
+#define DATA_LEN		(MPEG_TS_PACKET_LEN + sizeof(uint32_t)) /* MPEG-TS size + SPH */
+#define CIP_HEADER_LEN		(sizeof(uint32_t) * 2)
+#define STREAM_DATA_LEN		DATA_LEN + CIP_HEADER_LEN
+#define PDU_SIZE		(sizeof(struct avtp_stream_pdu) + CIP_HEADER_LEN + DATA_LEN)
+
+struct packet_entry {
+	STAILQ_ENTRY(packet_entry) entries;
+
+	struct timespec tspec;
+	uint8_t mpegts_packet[MPEG_TS_PACKET_LEN];
+};
+
+static STAILQ_HEAD(packet_queue, packet_entry) packets;
+static char ifname[IFNAMSIZ];
+static uint8_t macaddr[ETH_ALEN];
+static uint8_t expected_seq;
+static uint8_t expected_dbc;
+
+static struct argp_option options[] = {
+	{"dst-addr", 'd', "MACADDR", 0, "Stream Destination MAC address" },
+	{"ifname", 'i', "IFNAME", 0, "Network Interface" },
+	{ 0 }
+};
+
+static error_t parser(int key, char *arg, struct argp_state *state)
+{
+	int res;
+
+	switch (key) {
+	case 'd':
+		res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+					&macaddr[0], &macaddr[1], &macaddr[2],
+					&macaddr[3], &macaddr[4], &macaddr[5]);
+		if (res != 6) {
+			fprintf(stderr, "Invalid address\n");
+			exit(EXIT_FAILURE);
+		}
+
+		break;
+	case 'i':
+		strncpy(ifname, arg, sizeof(ifname) - 1);
+		break;
+	}
+
+	return 0;
+}
+
+static struct argp argp = { options, parser };
+
+/* Schedule 'MPEG-TS packet' to be presented at time specified by 'tspec'. */
+static int schedule_packet(int fd, struct timespec *tspec, uint8_t *mpeg_tsp)
+{
+	struct packet_entry *entry;
+
+	entry = malloc(sizeof(*entry));
+	if (!entry) {
+		fprintf(stderr, "Failed to allocate memory\n");
+		return -1;
+	}
+
+	entry->tspec.tv_sec = tspec->tv_sec;
+	entry->tspec.tv_nsec = tspec->tv_nsec;
+	memcpy(entry->mpegts_packet, mpeg_tsp, MPEG_TS_PACKET_LEN);
+
+	STAILQ_INSERT_TAIL(&packets, entry, entries);
+
+	/* If this was the first entry inserted onto the queue, we need to arm
+	 * the timer.
+	 */
+	if (STAILQ_FIRST(&packets) == entry) {
+		int res;
+
+		res = arm_timer(fd, tspec);
+		if (res < 0) {
+			STAILQ_REMOVE(&packets, entry, packet_entry, entries);
+			free(entry);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static bool is_valid_packet(struct avtp_stream_pdu *pdu)
+{
+	struct avtp_common_pdu *common = (struct avtp_common_pdu *) pdu;
+	uint64_t val64;
+	uint32_t val32;
+	int res;
+
+	res = avtp_pdu_get(common, AVTP_FIELD_SUBTYPE, &val32);
+	assert(res == 0);
+	if (val32 != AVTP_SUBTYPE_61883_IIDC) {
+		fprintf(stderr, "Subtype mismatch: expected %u, got %u\n",
+						AVTP_SUBTYPE_61883_IIDC, val32);
+		return false;
+	}
+
+	res = avtp_pdu_get(common, AVTP_FIELD_VERSION, &val32);
+	assert(res == 0);
+	if (val32 != 0) {
+		fprintf(stderr, "Version mismatch: expected %u, got %u\n",
+								0, val32);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_TV, &val64);
+	assert(res == 0);
+	if (val64 != 0) {
+		fprintf(stderr, "tv mismatch: expected %u, got %" PRIu64 "\n",
+								0, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_STREAM_ID, &val64);
+	assert(res == 0);
+	if (val64 != STREAM_ID) {
+		fprintf(stderr, "Stream ID mismatch: expected %" PRIu64
+				", got %" PRIu64 "\n", STREAM_ID, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_SEQ_NUM, &val64);
+	assert(res == 0);
+
+	if (val64 != expected_seq) {
+		/* If we have a sequence number mismatch, we simply log the
+		 * issue and continue to process the packet. We don't want to
+		 * invalidate it since it is a valid packet after all.
+		 */
+		fprintf(stderr, "Sequence number mismatch: expected %u, got %"
+				PRIu64 "\n", expected_seq, val64);
+		expected_seq = val64;
+	}
+
+	expected_seq++;
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_STREAM_DATA_LEN,
+									&val64);
+	assert(res == 0);
+	if (val64 != STREAM_DATA_LEN) {
+		fprintf(stderr, "Data len mismatch: expected %lu, got %"
+					PRIu64 "\n", STREAM_DATA_LEN, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_TAG, &val64);
+	assert(res == 0);
+	if (val64 != AVTP_IECIIDC_TAG_CIP) {
+		fprintf(stderr, "tag mismatch: expected %u, got %" PRIu64 "\n",
+						AVTP_IECIIDC_TAG_CIP, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CHANNEL, &val64);
+	assert(res == 0);
+	if (val64 != 31) {
+		fprintf(stderr, "channel mismatch: expected %u, got %" PRIu64
+							"\n", 31, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_SID, &val64);
+	assert(res == 0);
+	if (val64 != 63) {
+		fprintf(stderr, "sid mismatch: expected %u, got %" PRIu64 "\n",
+								63, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_DBS, &val64);
+	assert(res == 0);
+	if (val64 != 6) {
+		fprintf(stderr, "dbs mismatch: expected %u, got %" PRIu64 "\n",
+								6, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_FN, &val64);
+	assert(res == 0);
+	if (val64 != 3) {
+		fprintf(stderr, "fn mismatch: expected %u, got %" PRIu64 "\n",
+								3, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_QPC, &val64);
+	assert(res == 0);
+	if (val64 != 0) {
+		fprintf(stderr, "GV mismatch: expected %u, got %" PRIu64 "\n",
+								0, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_SPH, &val64);
+	assert(res == 0);
+	if (val64 != 1) {
+		fprintf(stderr, "sph mismatch: expected %u, got %" PRIu64 "\n",
+								1, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_FMT, &val64);
+	assert(res == 0);
+	if (val64 != 32) {
+		fprintf(stderr, "fmt mismatch: expected %u, got %" PRIu64 "\n",
+								32, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_TSF, &val64);
+	assert(res == 0);
+	if (val64 != 0) {
+		fprintf(stderr, "tsf mismatch: expected %u, got %" PRIu64 "\n",
+								0, val64);
+		return false;
+	}
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_DBC, &val64);
+	assert(res == 0);
+	if (val64 != expected_dbc) {
+		/* As with sequence mismatch, we'll not discard this packet,
+		 * only log that the mismatch happened */
+		fprintf(stderr, "dbc mismatch: expected %u, got %" PRIu64 "\n",
+							expected_dbc, val64);
+	}
+	expected_dbc += 8;
+
+	return true;
+}
+
+static int new_packet(int sk_fd, int timer_fd)
+{
+	int res;
+	ssize_t n;
+	uint32_t avtp_time;
+	struct timespec tspec;
+	struct avtp_stream_pdu *pdu = alloca(PDU_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) pdu->avtp_payload;
+	struct avtp_ieciidc_cip_source_packet *sp =
+		(struct avtp_ieciidc_cip_source_packet *) pay->cip_data_payload;
+
+	memset(pdu, 0, PDU_SIZE);
+
+	n = recv(sk_fd, pdu, PDU_SIZE, 0);
+	if (n < 0 || n != PDU_SIZE) {
+		perror("Failed to receive data");
+		return -1;
+	}
+
+	if (!is_valid_packet(pdu)) {
+		fprintf(stderr, "Dropping packet\n");
+		return 0;
+	}
+
+	/* There are no helpers for payload fields, so one must remember
+	 * of byte ordering */
+	avtp_time = ntohl(sp->avtp_source_packet_header_timestamp);
+
+	res = get_presentation_time(avtp_time, &tspec);
+	if (res < 0)
+		return -1;
+
+	res = schedule_packet(timer_fd, &tspec, sp->cip_with_sph_payload);
+	if (res < 0)
+		return -1;
+
+	return 0;
+}
+
+static int timeout(int fd)
+{
+	int res;
+	ssize_t n;
+	uint64_t expirations;
+	struct packet_entry *entry;
+
+	n = read(fd, &expirations, sizeof(uint64_t));
+	if (n < 0) {
+		perror("Failed to read timerfd");
+		return -1;
+	}
+
+	assert(expirations == 1);
+
+	entry = STAILQ_FIRST(&packets);
+	assert(entry != NULL);
+
+	res = present_data(entry->mpegts_packet, MPEG_TS_PACKET_LEN);
+	if (res < 0)
+		return -1;
+
+	STAILQ_REMOVE_HEAD(&packets, entries);
+	free(entry);
+
+	if (!STAILQ_EMPTY(&packets)) {
+		entry = STAILQ_FIRST(&packets);
+
+		res = arm_timer(fd, &entry->tspec);
+		if (res < 0)
+			return -1;
+	}
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int sk_fd, timer_fd, res;
+	struct pollfd fds[2];
+
+	argp_parse(&argp, argc, argv, 0, NULL, NULL);
+
+	STAILQ_INIT(&packets);
+
+	sk_fd = create_listener_socket(ifname, macaddr, ETH_P_TSN);
+	if (sk_fd < 0)
+		return 1;
+
+	timer_fd = timerfd_create(CLOCK_REALTIME, 0);
+	if (timer_fd < 0) {
+		close(sk_fd);
+		return 1;
+	}
+
+	fds[0].fd = sk_fd;
+	fds[0].events = POLLIN;
+	fds[1].fd = timer_fd;
+	fds[1].events = POLLIN;
+
+	while (1) {
+		res = poll(fds, 2, -1);
+		if (res < 0) {
+			perror("Failed to poll() fds");
+			goto err;
+		}
+
+		if (fds[0].revents & POLLIN) {
+			res = new_packet(sk_fd, timer_fd);
+			if (res < 0)
+				goto err;
+		}
+
+		if (fds[1].revents & POLLIN) {
+			res = timeout(timer_fd);
+			if (res < 0)
+				goto err;
+		}
+	}
+
+	return 0;
+
+err:
+	close(sk_fd);
+	close(timer_fd);
+	return 1;
+}

--- a/examples/ieciidc-talker.c
+++ b/examples/ieciidc-talker.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* IEC 61883/IIDC Talker example.
+ *
+ * This example implements a very simple IEC 61883 talker application which
+ * reads an MPEG-TS stream from stdin, creates AVTP IEC 61883/IIDC packets and
+ * transmits them via the network.
+ *
+ * For simplicity, the example supports only MPEG-TS streams, and only one
+ * source packet is packed into each AVTP packet sent.
+ *
+ * TSN stream parameters (e.g. destination mac address, traffic priority) are
+ * passed via command-line arguments. Run 'ieciidc-talker --help' for more
+ * information.
+ *
+ * In order to have this example working properly, make sure you have
+ * configured FQTSS feature from your NIC according (for further information
+ * see tc-cbs(8)). Also, this example relies on system clock to set the AVTP
+ * timestamp so make sure it is synchronized with the PTP Hardware Clock (PHC)
+ * from your NIC and that the PHC is synchronized with the network clock. For
+ * further information see ptp4l(8) and phc2sys(8).
+ *
+ * The easiest way to use this example is by combining it with a GStreamer
+ * pipeline. We use GStreamer to provide an MPEG-TS stream that is sent to
+ * stdout, from where this example reads the stream. So, to generate
+ * an MPEG-TS video to send via TSN network, you can do something like:
+ *
+ * $ gst-launch-1.0 -e -q videotestsrc pattern=ball ! x264enc
+ *  ! mpegtsmux ! filesink location=/dev/stdout
+ *  | ieciidc-talker <args>
+ *
+ */
+
+#include <alloca.h>
+#include <argp.h>
+#include <arpa/inet.h>
+#include <assert.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "avtp.h"
+#include "avtp_ieciidc.h"
+#include "examples/common.h"
+
+#define STREAM_ID		0xAABBCCDDEEFF0001
+#define MPEG_TS_PACKET_LEN	188
+
+#define DATA_LEN		(MPEG_TS_PACKET_LEN + sizeof(uint32_t)) /* MPEG-TS size + SPH */
+#define CIP_HEADER_LEN		(sizeof(uint32_t) * 2)
+#define STREAM_DATA_LEN		DATA_LEN + CIP_HEADER_LEN
+#define PDU_SIZE		(sizeof(struct avtp_stream_pdu) + CIP_HEADER_LEN + DATA_LEN)
+
+static char ifname[IFNAMSIZ];
+static uint8_t macaddr[ETH_ALEN];
+static int priority = -1;
+static int max_transit_time;
+
+static struct argp_option options[] = {
+	{"dst-addr", 'd', "MACADDR", 0, "Stream Destination MAC address" },
+	{"ifname", 'i', "IFNAME", 0, "Network Interface" },
+	{"max-transit-time", 'm', "MSEC", 0, "Maximum Transit Time in ms" },
+	{"prio", 'p', "NUM", 0, "SO_PRIORITY to be set in socket" },
+	{ 0 }
+};
+
+static error_t parser(int key, char *arg, struct argp_state *state)
+{
+	int res;
+
+	switch (key) {
+	case 'd':
+		res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+					&macaddr[0], &macaddr[1], &macaddr[2],
+					&macaddr[3], &macaddr[4], &macaddr[5]);
+		if (res != 6) {
+			fprintf(stderr, "Invalid address\n");
+			exit(EXIT_FAILURE);
+		}
+
+		break;
+	case 'i':
+		strncpy(ifname, arg, sizeof(ifname) - 1);
+		break;
+	case 'm':
+		max_transit_time = atoi(arg);
+		break;
+	case 'p':
+		priority = atoi(arg);
+		break;
+	}
+
+	return 0;
+}
+
+static struct argp argp = { options, parser };
+
+static void init_pdu(struct avtp_stream_pdu *pdu)
+{
+	int res;
+
+	res = avtp_ieciidc_pdu_init(pdu, AVTP_IECIIDC_TAG_CIP);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_TV, 0);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_STREAM_ID,
+								STREAM_ID);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu,
+			AVTP_IECIIDC_FIELD_STREAM_DATA_LEN, STREAM_DATA_LEN);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_GV, 0);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_GATEWAY_INFO, 0);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CHANNEL, 31);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_QI_1, 0);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_SID, 63);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_DBS, 6);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_FN, 3);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_QPC, 0);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_SPH, 1);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_QI_2, 2);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_FMT, 32);
+	assert(res == 0);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_TSF, 0);
+	assert(res == 0);
+}
+
+int main(int argc, char *argv[])
+{
+	int fd, res;
+	struct sockaddr_ll sk_addr;
+	struct avtp_stream_pdu *pdu = alloca(PDU_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *)pdu->avtp_payload;
+	uint8_t seq_num = 0;
+	uint8_t dbc = 0;
+
+	argp_parse(&argp, argc, argv, 0, NULL, NULL);
+
+	fd = create_talker_socket(priority);
+	if (fd < 0)
+		return 1;
+
+	res = setup_socket_address(fd, ifname, macaddr, ETH_P_TSN, &sk_addr);
+	if (res < 0)
+		goto err;
+
+	init_pdu(pdu);
+
+	while (1) {
+		ssize_t n;
+		uint32_t avtp_time;
+		struct avtp_ieciidc_cip_source_packet *sp;
+
+		memset(pay->cip_data_payload, 0, DATA_LEN);
+		sp = (struct avtp_ieciidc_cip_source_packet *)
+							pay->cip_data_payload;
+
+		n = read(STDIN_FILENO, sp->cip_with_sph_payload,
+							MPEG_TS_PACKET_LEN);
+		if (n == 0)
+			break;
+
+		if (n != MPEG_TS_PACKET_LEN) {
+			fprintf(stderr, "read %zd bytes, expected %d\n", n,
+							MPEG_TS_PACKET_LEN);
+		}
+
+		res = calculate_avtp_time(&avtp_time, max_transit_time);
+		if (res < 0) {
+			fprintf(stderr, "Failed to calculate avtp time\n");
+			goto err;
+		}
+
+		/* There are no helpers for payload fields, so one must remember
+		 * of byte ordering
+		 */
+		sp->avtp_source_packet_header_timestamp = htonl(avtp_time);
+
+		res = avtp_ieciidc_pdu_set(pdu,
+					AVTP_IECIIDC_FIELD_SEQ_NUM, seq_num++);
+		assert(res == 0);
+
+		res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_DBC,
+									dbc);
+		assert(res == 0);
+		/* We just send one MPEG-TS packet per AVTP packet, so we
+		 * increase dbc by the number of blocks on one MPEG-TS packet
+		 */
+		dbc += 8;
+
+		n = sendto(fd, pdu, PDU_SIZE, 0, (struct sockaddr *) &sk_addr,
+							sizeof(sk_addr));
+		if (n < 0) {
+			perror("Failed to send data");
+			goto err;
+		}
+
+		if (n != PDU_SIZE) {
+			fprintf(stderr, "wrote %zd bytes, expected %zd\n", n,
+								PDU_SIZE);
+		}
+	}
+
+	close(fd);
+	return 0;
+
+err:
+	close(fd);
+	return 1;
+}

--- a/include/avtp_ieciidc.h
+++ b/include/avtp_ieciidc.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <errno.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define AVTP_IECIIDC_TAG_NO_CIP		0x00
+#define AVTP_IECIIDC_TAG_CIP		0x01
+
+enum avtp_ieciidc_field {
+	AVTP_IECIIDC_FIELD_SV,
+	AVTP_IECIIDC_FIELD_MR,
+	AVTP_IECIIDC_FIELD_TV,
+	AVTP_IECIIDC_FIELD_SEQ_NUM,
+	AVTP_IECIIDC_FIELD_TU,
+	AVTP_IECIIDC_FIELD_STREAM_ID,
+	AVTP_IECIIDC_FIELD_TIMESTAMP,
+	AVTP_IECIIDC_FIELD_STREAM_DATA_LEN,
+	AVTP_IECIIDC_FIELD_GV,
+	AVTP_IECIIDC_FIELD_GATEWAY_INFO,
+	AVTP_IECIIDC_FIELD_TAG,
+	AVTP_IECIIDC_FIELD_CHANNEL,
+	AVTP_IECIIDC_FIELD_TCODE,
+	AVTP_IECIIDC_FIELD_SY,
+	AVTP_IECIIDC_FIELD_CIP_QI_1,
+	AVTP_IECIIDC_FIELD_CIP_QI_2,
+	AVTP_IECIIDC_FIELD_CIP_SID,
+	AVTP_IECIIDC_FIELD_CIP_DBS,
+	AVTP_IECIIDC_FIELD_CIP_FN,
+	AVTP_IECIIDC_FIELD_CIP_QPC,
+	AVTP_IECIIDC_FIELD_CIP_SPH,
+	AVTP_IECIIDC_FIELD_CIP_DBC,
+	AVTP_IECIIDC_FIELD_CIP_FMT,
+	AVTP_IECIIDC_FIELD_CIP_SYT,
+
+	/* Fields defined below are the FDF - Format Dependent Field - fields.
+	 * As they are poorly described in the IEEE 1722 - it usually refers to
+	 * the IEC 61883-1, which in turn refers to each relevant IEC 61883
+	 * part, this comment is an attempt to summarize the description of
+	 * those fields, as described in IEC 61883.
+	 *
+	 * Note that FDF is the one defined on Figure 23 of IEEE 1722-2016, and
+	 * FDF_3 is the one with 3 octets, seen on Figure 24 of the same
+	 * standard.
+	 *
+	 *  - IEC 61883-4 uses FDF_3, with fields:
+	 *    - TSF (Bit 0)
+	 *
+	 *  - IEC 61883-6 uses FDF, with fields:
+	 *    - EVT (Bits 2-3)
+	 *    - SFC (Bits 5-7)
+	 *    - N   (Bit 4)
+	 *    - NO-DATA (All 8 bits set to 1)
+	 *
+	 *  - IEC 61883-7 uses FDF_3, with fields:
+	 *    - TSF (Bit 0)
+	 *
+	 *  - IEC 61883-8 uses FDF, with fields:
+	 *    - ND (Bit 0)
+	 */
+	AVTP_IECIIDC_FIELD_CIP_TSF,
+	AVTP_IECIIDC_FIELD_CIP_EVT,
+	AVTP_IECIIDC_FIELD_CIP_SFC,
+	AVTP_IECIIDC_FIELD_CIP_N,
+	AVTP_IECIIDC_FIELD_CIP_ND,
+	AVTP_IECIIDC_FIELD_CIP_NO_DATA,
+	AVTP_IECIIDC_FIELD_MAX,
+};
+
+struct avtp_ieciidc_cip_payload {
+	uint32_t cip_1;
+	uint32_t cip_2;
+	uint8_t cip_data_payload[0];
+};
+
+struct avtp_ieciidc_cip_source_packet {
+	uint32_t avtp_source_packet_header_timestamp;
+	uint8_t cip_with_sph_payload[0];
+};
+
+/* Get value from IEC 61883/IIDC AVTPDU field.
+ * @pdu: Pointer to PDU struct.
+ * @field: PDU field to be retrieved.
+ * @val: Pointer to variable which the retrieved value should be saved.
+ *
+ * Returns:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_ieciidc_pdu_get(const struct avtp_stream_pdu *pdu,
+			enum avtp_ieciidc_field field, uint64_t *val);
+
+/* Set value from IEC 61883/IIDC AVTPDU field.
+ * @pdu: Pointer to PDU struct.
+ * @field: PDU field to be set.
+ * @val: Value to be set.
+ *
+ * Returns:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_ieciidc_pdu_set(struct avtp_stream_pdu *pdu,
+				enum avtp_ieciidc_field field, uint64_t val);
+
+/* Initialize IEC 61883/IIDC AVTPDU. The following fields are pre-initialised:
+ * 'subtype' -> AVTP_SUBTYPE_61883_IIDC
+ * 'sv' -> 0x01
+ * 'tcode' -> 0x0A
+ * 'tag' -> tag informed on parameter
+ * All other fields are set to zero.
+ * @pdu: Pointer to PDU struct.
+ * @tag: Value of AVTP_IECIIDC_FIELD_TAG.
+ *
+ * Return values:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_ieciidc_pdu_init(struct avtp_stream_pdu *pdu, uint8_t tag);
+
+#ifdef __cplusplus
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -83,11 +83,21 @@ test_cvf = executable(
 	build_by_default: false,
 )
 
+test_ieciidc = executable(
+	'test-ieciidc',
+	'unit/test-ieciidc.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	dependencies: dependency('cmocka'),
+	build_by_default: false,
+)
+
 test('AVTP API', test_avtp)
 test('Stream API', test_stream)
 test('AAF API', test_aaf)
 test('CRF API', test_crf)
 test('CVF API', test_cvf)
+test('IEC61883/IIDC API', test_ieciidc)
 
 cc = meson.get_compiler('c')
 mdep = cc.find_library('m', required : false)

--- a/meson.build
+++ b/meson.build
@@ -157,3 +157,12 @@ executable(
 	link_with: avtp_lib,
 	build_by_default: false,
 )
+
+executable(
+	'ieciidc-talker',
+	'examples/ieciidc-talker.c',
+	'examples/common.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	build_by_default: false,
+)

--- a/meson.build
+++ b/meson.build
@@ -166,3 +166,12 @@ executable(
 	link_with: avtp_lib,
 	build_by_default: false,
 )
+
+executable(
+	'ieciidc-listener',
+	'examples/ieciidc-listener.c',
+	'examples/common.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	build_by_default: false,
+)

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ avtp_lib = library(
 	 'src/avtp_aaf.c',
 	 'src/avtp_crf.c',
 	 'src/avtp_cvf.c',
+	 'src/avtp_ieciidc.c',
 	 'src/avtp_stream.c',
 	],
 	version: meson.project_version(),
@@ -24,6 +25,7 @@ install_headers(
 	'include/avtp_aaf.h',
 	'include/avtp_crf.h',
 	'include/avtp_cvf.h',
+	'include/avtp_ieciidc.h',
 )
 
 pkg = import('pkgconfig')

--- a/src/avtp_ieciidc.c
+++ b/src/avtp_ieciidc.c
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arpa/inet.h>
+#include <endian.h>
+#include <string.h>
+
+#include "avtp.h"
+#include "avtp_ieciidc.h"
+#include "avtp_stream.h"
+#include "util.h"
+
+#define SHIFT_GV			(31 - 14)
+#define SHIFT_TAG			(31 - 17)
+#define SHIFT_CHANNEL			(31 - 23)
+#define SHIFT_TCODE			(31 - 27)
+#define SHIFT_QI_1			(31 - 1)
+#define SHIFT_QI_2			(31 - 1)
+#define SHIFT_SID			(31 - 7)
+#define SHIFT_DBS			(31 - 15)
+#define SHIFT_FN			(31 - 17)
+#define SHIFT_QPC			(31 - 20)
+#define SHIFT_SPH			(31 - 21)
+#define SHIFT_SPH			(31 - 21)
+#define SHIFT_FMT			(31 - 7)
+#define SHIFT_TSF			(31 - 8)
+#define SHIFT_EVT			(31 - 11)
+#define SHIFT_SFC			(31 - 15)
+#define SHIFT_N				(31 - 12)
+#define SHIFT_NO_DATA			(31 - 15)
+#define SHIFT_ND			(31 - 8)
+
+#define MASK_GV				(BITMASK(1) << SHIFT_GV)
+#define MASK_TAG			(BITMASK(2) << SHIFT_TAG)
+#define MASK_CHANNEL			(BITMASK(6) << SHIFT_CHANNEL)
+#define MASK_TCODE			(BITMASK(4) << SHIFT_TCODE)
+#define MASK_SY				(BITMASK(4))
+#define MASK_QI_1			(BITMASK(2) << SHIFT_QI_1)
+#define MASK_QI_2			(BITMASK(2) << SHIFT_QI_2)
+#define MASK_SID			(BITMASK(6) << SHIFT_SID)
+#define MASK_DBS			(BITMASK(8) << SHIFT_DBS)
+#define MASK_FN				(BITMASK(2) << SHIFT_FN)
+#define MASK_QPC			(BITMASK(3) << SHIFT_QPC)
+#define MASK_SPH			(BITMASK(1) << SHIFT_SPH)
+#define MASK_DBC			(BITMASK(8))
+#define MASK_FMT			(BITMASK(6) << SHIFT_FMT)
+#define MASK_SYT			(BITMASK(16))
+#define MASK_TSF			(BITMASK(1) << SHIFT_TSF)
+#define MASK_EVT			(BITMASK(2) << SHIFT_EVT)
+#define MASK_SFC			(BITMASK(3) << SHIFT_SFC)
+#define MASK_N				(BITMASK(1) << SHIFT_N)
+#define MASK_NO_DATA			(BITMASK(8) << SHIFT_NO_DATA)
+#define MASK_ND				(BITMASK(1) << SHIFT_ND)
+
+static int get_field_value(const struct avtp_stream_pdu *pdu,
+				enum avtp_ieciidc_field field, uint64_t *val)
+{
+	uint32_t bitmap, mask;
+	uint8_t shift;
+
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) pdu->avtp_payload;
+
+	switch (field) {
+	case AVTP_IECIIDC_FIELD_GV:
+		mask = MASK_GV;
+		shift = SHIFT_GV;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_IECIIDC_FIELD_TAG:
+		mask = MASK_TAG;
+		shift = SHIFT_TAG;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	case AVTP_IECIIDC_FIELD_CHANNEL:
+		mask = MASK_CHANNEL;
+		shift = SHIFT_CHANNEL;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	case AVTP_IECIIDC_FIELD_TCODE:
+		mask = MASK_TCODE;
+		shift = SHIFT_TCODE;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	case AVTP_IECIIDC_FIELD_SY:
+		mask = MASK_SY;
+		shift = 0;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_QI_1:
+		mask = MASK_QI_1;
+		shift = SHIFT_QI_1;
+		bitmap = ntohl(pay->cip_1);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_QI_2:
+		mask = MASK_QI_2;
+		shift = SHIFT_QI_2;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_SID:
+		mask = MASK_SID;
+		shift = SHIFT_SID;
+		bitmap = ntohl(pay->cip_1);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_DBS:
+		mask = MASK_DBS;
+		shift = SHIFT_DBS;
+		bitmap = ntohl(pay->cip_1);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_FN:
+		mask = MASK_FN;
+		shift = SHIFT_FN;
+		bitmap = ntohl(pay->cip_1);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_QPC:
+		mask = MASK_QPC;
+		shift = SHIFT_QPC;
+		bitmap = ntohl(pay->cip_1);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_SPH:
+		mask = MASK_SPH;
+		shift = SHIFT_SPH;
+		bitmap = ntohl(pay->cip_1);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_DBC:
+		mask = MASK_DBC;
+		shift = 0;
+		bitmap = ntohl(pay->cip_1);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_FMT:
+		mask = MASK_FMT;
+		shift = SHIFT_FMT;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_TSF:
+		mask = MASK_TSF;
+		shift = SHIFT_TSF;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_EVT:
+		mask = MASK_EVT;
+		shift = SHIFT_EVT;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_SFC:
+		mask = MASK_SFC;
+		shift = SHIFT_SFC;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_N:
+		mask = MASK_N;
+		shift = SHIFT_N;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_ND:
+		mask = MASK_ND;
+		shift = SHIFT_ND;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_NO_DATA:
+		mask = MASK_NO_DATA;
+		shift = SHIFT_NO_DATA;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_SYT:
+		mask = MASK_SYT;
+		shift = 0;
+		bitmap = ntohl(pay->cip_2);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	*val = BITMAP_GET_VALUE(bitmap, mask, shift);
+
+	return 0;
+}
+
+int avtp_ieciidc_pdu_get(const struct avtp_stream_pdu *pdu,
+				enum avtp_ieciidc_field field, uint64_t *val)
+{
+	int res;
+
+	if (!pdu || !val)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_IECIIDC_FIELD_SV:
+	case AVTP_IECIIDC_FIELD_MR:
+	case AVTP_IECIIDC_FIELD_TV:
+	case AVTP_IECIIDC_FIELD_SEQ_NUM:
+	case AVTP_IECIIDC_FIELD_TU:
+	case AVTP_IECIIDC_FIELD_STREAM_DATA_LEN:
+	case AVTP_IECIIDC_FIELD_TIMESTAMP:
+	case AVTP_IECIIDC_FIELD_STREAM_ID:
+		res = avtp_stream_pdu_get(pdu, (enum avtp_stream_field) field,
+									val);
+		break;
+	case AVTP_IECIIDC_FIELD_GV:
+	case AVTP_IECIIDC_FIELD_TAG:
+	case AVTP_IECIIDC_FIELD_CHANNEL:
+	case AVTP_IECIIDC_FIELD_TCODE:
+	case AVTP_IECIIDC_FIELD_SY:
+	case AVTP_IECIIDC_FIELD_CIP_QI_1:
+	case AVTP_IECIIDC_FIELD_CIP_QI_2:
+	case AVTP_IECIIDC_FIELD_CIP_SID:
+	case AVTP_IECIIDC_FIELD_CIP_DBS:
+	case AVTP_IECIIDC_FIELD_CIP_FN:
+	case AVTP_IECIIDC_FIELD_CIP_QPC:
+	case AVTP_IECIIDC_FIELD_CIP_SPH:
+	case AVTP_IECIIDC_FIELD_CIP_DBC:
+	case AVTP_IECIIDC_FIELD_CIP_FMT:
+	case AVTP_IECIIDC_FIELD_CIP_TSF:
+	case AVTP_IECIIDC_FIELD_CIP_EVT:
+	case AVTP_IECIIDC_FIELD_CIP_SFC:
+	case AVTP_IECIIDC_FIELD_CIP_N:
+	case AVTP_IECIIDC_FIELD_CIP_ND:
+	case AVTP_IECIIDC_FIELD_CIP_NO_DATA:
+	case AVTP_IECIIDC_FIELD_CIP_SYT:
+		res = get_field_value(pdu, field, val);
+		break;
+	case AVTP_IECIIDC_FIELD_GATEWAY_INFO:
+		*val = ntohl(pdu->format_specific);
+		res = 0;
+		break;
+	default:
+		res = -EINVAL;
+		break;
+	}
+
+	return res;
+}
+
+static int set_field_value(struct avtp_stream_pdu *pdu,
+			enum avtp_ieciidc_field field, uint64_t value)
+{
+	uint32_t *ptr, bitmap, mask;
+	uint8_t shift;
+
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) pdu->avtp_payload;
+
+	switch (field) {
+	case AVTP_IECIIDC_FIELD_GV:
+		mask = MASK_GV;
+		shift = SHIFT_GV;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_IECIIDC_FIELD_TAG:
+		mask = MASK_TAG;
+		shift = SHIFT_TAG;
+		ptr = &pdu->packet_info;
+		break;
+	case AVTP_IECIIDC_FIELD_CHANNEL:
+		mask = MASK_CHANNEL;
+		shift = SHIFT_CHANNEL;
+		ptr = &pdu->packet_info;
+		break;
+	case AVTP_IECIIDC_FIELD_TCODE:
+		mask = MASK_TCODE;
+		shift = SHIFT_TCODE;
+		ptr = &pdu->packet_info;
+		break;
+	case AVTP_IECIIDC_FIELD_SY:
+		mask = MASK_SY;
+		shift = 0;
+		ptr = &pdu->packet_info;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_QI_1:
+		mask = MASK_QI_1;
+		shift = SHIFT_QI_1;
+		ptr = &pay->cip_1;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_QI_2:
+		mask = MASK_QI_2;
+		shift = SHIFT_QI_2;
+		ptr = &pay->cip_2;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_SID:
+		mask = MASK_SID;
+		shift = SHIFT_SID;
+		ptr = &pay->cip_1;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_DBS:
+		mask = MASK_DBS;
+		shift = SHIFT_DBS;
+		ptr = &pay->cip_1;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_FN:
+		mask = MASK_FN;
+		shift = SHIFT_FN;
+		ptr = &pay->cip_1;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_QPC:
+		mask = MASK_QPC;
+		shift = SHIFT_QPC;
+		ptr = &pay->cip_1;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_SPH:
+		mask = MASK_SPH;
+		shift = SHIFT_SPH;
+		ptr = &pay->cip_1;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_DBC:
+		mask = MASK_DBC;
+		shift = 0;
+		ptr = &pay->cip_1;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_FMT:
+		mask = MASK_FMT;
+		shift = SHIFT_FMT;
+		ptr = &pay->cip_2;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_TSF:
+		mask = MASK_TSF;
+		shift = SHIFT_TSF;
+		ptr = &pay->cip_2;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_EVT:
+		mask = MASK_EVT;
+		shift = SHIFT_EVT;
+		ptr = &pay->cip_2;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_SFC:
+		mask = MASK_SFC;
+		shift = SHIFT_SFC;
+		ptr = &pay->cip_2;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_N:
+		mask = MASK_N;
+		shift = SHIFT_N;
+		ptr = &pay->cip_2;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_ND:
+		mask = MASK_ND;
+		shift = SHIFT_ND;
+		ptr = &pay->cip_2;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_NO_DATA:
+		mask = MASK_NO_DATA;
+		shift = SHIFT_NO_DATA;
+		ptr = &pay->cip_2;
+		break;
+	case AVTP_IECIIDC_FIELD_CIP_SYT:
+		mask = MASK_SYT;
+		shift = 0;
+		ptr = &pay->cip_2;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	bitmap = ntohl(*ptr);
+
+	BITMAP_SET_VALUE(bitmap, value, mask, shift);
+
+	*ptr = htonl(bitmap);
+
+	return 0;
+}
+
+int avtp_ieciidc_pdu_set(struct avtp_stream_pdu *pdu,
+			enum avtp_ieciidc_field field, uint64_t value)
+{
+	int res;
+
+	if (!pdu)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_IECIIDC_FIELD_SV:
+	case AVTP_IECIIDC_FIELD_MR:
+	case AVTP_IECIIDC_FIELD_TV:
+	case AVTP_IECIIDC_FIELD_SEQ_NUM:
+	case AVTP_IECIIDC_FIELD_TU:
+	case AVTP_IECIIDC_FIELD_STREAM_DATA_LEN:
+	case AVTP_IECIIDC_FIELD_TIMESTAMP:
+	case AVTP_IECIIDC_FIELD_STREAM_ID:
+		res = avtp_stream_pdu_set(pdu, (enum avtp_stream_field) field,
+									value);
+		break;
+	case AVTP_IECIIDC_FIELD_GV:
+	case AVTP_IECIIDC_FIELD_TAG:
+	case AVTP_IECIIDC_FIELD_CHANNEL:
+	case AVTP_IECIIDC_FIELD_TCODE:
+	case AVTP_IECIIDC_FIELD_SY:
+	case AVTP_IECIIDC_FIELD_CIP_QI_1:
+	case AVTP_IECIIDC_FIELD_CIP_QI_2:
+	case AVTP_IECIIDC_FIELD_CIP_SID:
+	case AVTP_IECIIDC_FIELD_CIP_DBS:
+	case AVTP_IECIIDC_FIELD_CIP_FN:
+	case AVTP_IECIIDC_FIELD_CIP_QPC:
+	case AVTP_IECIIDC_FIELD_CIP_SPH:
+	case AVTP_IECIIDC_FIELD_CIP_DBC:
+	case AVTP_IECIIDC_FIELD_CIP_FMT:
+	case AVTP_IECIIDC_FIELD_CIP_TSF:
+	case AVTP_IECIIDC_FIELD_CIP_EVT:
+	case AVTP_IECIIDC_FIELD_CIP_SFC:
+	case AVTP_IECIIDC_FIELD_CIP_N:
+	case AVTP_IECIIDC_FIELD_CIP_ND:
+	case AVTP_IECIIDC_FIELD_CIP_NO_DATA:
+	case AVTP_IECIIDC_FIELD_CIP_SYT:
+		res = set_field_value(pdu, field, value);
+		break;
+	case AVTP_IECIIDC_FIELD_GATEWAY_INFO:
+		pdu->format_specific = htonl(value);
+		res = 0;
+		break;
+	default:
+		res = -EINVAL;
+		break;
+	}
+
+	return res;
+}
+
+int avtp_ieciidc_pdu_init(struct avtp_stream_pdu *pdu, uint8_t tag)
+{
+	int res;
+
+	if (!pdu || tag > 0x01)
+		return -EINVAL;
+
+	memset(pdu, 0, sizeof(struct avtp_stream_pdu));
+
+	res = avtp_pdu_set((struct avtp_common_pdu *) pdu, AVTP_FIELD_SUBTYPE,
+						AVTP_SUBTYPE_61883_IIDC);
+	if (res < 0)
+		return res;
+
+	res = avtp_stream_pdu_set((struct avtp_stream_pdu *) pdu,
+						AVTP_STREAM_FIELD_SV, 1);
+	if (res < 0)
+		return res;
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_TCODE, 0x0A);
+	if (res < 0)
+		return res;
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_TAG, tag);
+	if (res < 0)
+		return res;
+
+	return 0;
+}

--- a/travis.sh
+++ b/travis.sh
@@ -11,4 +11,5 @@ ninja -C build/ \
 	crf-listener \
 	cvf-talker \
 	cvf-listener \
-	ieciidc-talker
+	ieciidc-talker \
+	ieciidc-listener

--- a/travis.sh
+++ b/travis.sh
@@ -3,4 +3,12 @@ set -ev
 
 mkdir build
 CFLAGS=-Wno-missing-braces meson . build
-ninja -C build/ test aaf-talker aaf-listener crf-talker crf-listener cvf-talker cvf-listener
+ninja -C build/ \
+	test \
+	aaf-talker \
+	aaf-listener \
+	crf-talker \
+	crf-listener \
+	cvf-talker \
+	cvf-listener \
+	ieciidc-talker

--- a/unit/test-ieciidc.c
+++ b/unit/test-ieciidc.c
@@ -1,0 +1,1267 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <alloca.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <arpa/inet.h>
+
+#include "avtp.h"
+#include "avtp_ieciidc.h"
+
+#define IECIIDC_PDU_HEADER_SIZE (sizeof(struct avtp_stream_pdu) + \
+				sizeof(struct avtp_ieciidc_cip_payload))
+#define IECIIDC_PDU_HEADER_SPH_SIZE (IECIIDC_PDU_HEADER_SIZE + \
+							sizeof(uint32_t))
+
+static void ieciidc_get_field_null_pdu(void **state)
+{
+	int res;
+	uint64_t val = 1;
+
+	res = avtp_ieciidc_pdu_get(NULL, AVTP_IECIIDC_FIELD_GV, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void ieciidc_get_field_null_val(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_GV, NULL);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void ieciidc_get_field_invalid_field(void **state)
+{
+	int res;
+	uint64_t val = 1;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_MAX, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void ieciidc_get_field_sv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'sv' field to 1. */
+	pdu.subtype_data = htonl(0x00800000);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_SV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void ieciidc_get_field_mr(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'mr' field to 1. */
+	pdu.subtype_data = htonl(0x00080000);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_MR, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void ieciidc_get_field_tv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'tv' field to 1. */
+	pdu.subtype_data = htonl(0x00010000);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_TV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void ieciidc_get_field_seq_num(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'sequence_num' field to 0x55. */
+	pdu.subtype_data = htonl(0x00005500);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_SEQ_NUM, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x55);
+}
+
+static void ieciidc_get_field_tu(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'tu' field to 1. */
+	pdu.subtype_data = htonl(0x00000001);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_TU, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void ieciidc_get_field_stream_id(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'stream_id' field to 0xAABBCCDDEEFF0001. */
+	pdu.stream_id = htobe64(0xAABBCCDDEEFF0001);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_STREAM_ID, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAABBCCDDEEFF0001);
+}
+
+static void ieciidc_get_field_timestamp(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'avtp_timestamp' field to 0x80C0FFEE. */
+	pdu.avtp_time = htonl(0x80C0FFEE);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_TIMESTAMP, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x80C0FFEE);
+}
+
+static void ieciidc_get_field_data_len(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'stream_data_length' field to 0xAAAA. */
+	pdu.packet_info = htonl(0xAAAA0000);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_STREAM_DATA_LEN,
+									&val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAAAA);
+}
+
+static void ieciidc_get_field_gv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'gv' field to 1. */
+	pdu.subtype_data = htonl(0x00020000);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_GV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x1);
+}
+
+static void ieciidc_get_field_gateway_info(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'gateway info' field to 0x80C0FFEE. */
+	pdu.format_specific = htonl(0x80C0FFEE);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_GATEWAY_INFO, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x80C0FFEE);
+}
+
+static void ieciidc_get_field_tag(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'tag' field to 1. */
+	pdu.packet_info = htonl(0x00004000);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_TAG, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x1);
+}
+
+static void ieciidc_get_field_channel(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'channel' field to 42. */
+	pdu.packet_info = htonl(0x00002A00);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_CHANNEL, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 42);
+}
+
+static void ieciidc_get_field_tcode(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'tcode' field to 10. */
+	pdu.packet_info = htonl(0x000000A0);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_TCODE, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 10);
+}
+
+static void ieciidc_get_field_sy(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'sy' field to 10. */
+	pdu.packet_info = htonl(0x0000000A);
+
+	res = avtp_ieciidc_pdu_get(&pdu, AVTP_IECIIDC_FIELD_SY, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 10);
+}
+
+static void ieciidc_get_field_qi_1(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'qi_1' field to 2. */
+	pay->cip_1 = htonl(0x80000000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_QI_1, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 2);
+}
+
+static void ieciidc_get_field_qi_2(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'qi_2' field to 2. */
+	pay->cip_2 = htonl(0x80000000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_QI_2, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 2);
+}
+
+static void ieciidc_get_field_sid(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'sid' field to 42. */
+	pay->cip_1 = htonl(0x2A000000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_SID, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 42);
+}
+
+static void ieciidc_get_field_dbs(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'dbs' field to 0xAA. */
+	pay->cip_1 = htonl(0x00AA0000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_DBS, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAA);
+}
+
+static void ieciidc_get_field_fn(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'fn' field to 2. */
+	pay->cip_1 = htonl(0x00008000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_FN, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 2);
+}
+
+static void ieciidc_get_field_qpc(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'qpc' field to 5. */
+	pay->cip_1 = htonl(0x00002800);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_QPC, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 5);
+}
+
+static void ieciidc_get_field_sph(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'sph' field to 1. */
+	pay->cip_1 = htonl(0x0000400);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_SPH, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void ieciidc_get_field_dbc(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'dbc' field to 0xAA. */
+	pay->cip_1 = htonl(0x000000AA);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_DBC, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAA);
+}
+
+static void ieciidc_get_field_fmt(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'fmt' field to 42. */
+	pay->cip_2 = htonl(0x2A000000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_FMT, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 42);
+}
+
+static void ieciidc_get_field_syt(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'syt' field to 0xAAAA. */
+	pay->cip_2 = htonl(0x0000AAAA);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_SYT, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAAAA);
+}
+
+static void ieciidc_get_field_tsf(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'tsf' field to 1. */
+	pay->cip_2 = htonl(0x00800000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_TSF, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void ieciidc_get_field_evt(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'evt' field to 2. */
+	pay->cip_2 = htonl(0x00200000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_EVT, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 2);
+}
+
+static void ieciidc_get_field_sfc(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'sfc' field to 5. */
+	pay->cip_2 = htonl(0x00050000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_SFC, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 5);
+}
+
+static void ieciidc_get_field_n(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'n' field to 1. */
+	pay->cip_2 = htonl(0x00080000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_N, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void ieciidc_get_field_nd(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'nd' field to 1. */
+	pay->cip_2 = htonl(0x00800000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_ND, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void ieciidc_get_field_no_data(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	/* Set 'no_data' field to 0xFF. */
+	pay->cip_2 = htonl(0x00FF0000);
+
+	res = avtp_ieciidc_pdu_get(pdu, AVTP_IECIIDC_FIELD_CIP_NO_DATA, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xFF);
+}
+
+static void ieciidc_set_field_null_pdu(void **state)
+{
+	int res;
+
+	res = avtp_ieciidc_pdu_set(NULL, AVTP_IECIIDC_FIELD_SV, 1);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void ieciidc_set_field_invalid_field(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_MAX, 1);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void ieciidc_set_field_sv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_SV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00800000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_mr(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_MR, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00080000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_tv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_TV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00010000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_seq_num(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_SEQ_NUM, 0x55);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00005500);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_tu(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_TU, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00000001);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_stream_id(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_STREAM_ID,
+							0xAABBCCDDEEFF0001);
+
+	assert_int_equal(res, 0);
+	assert_true(be64toh(pdu.stream_id) == 0xAABBCCDDEEFF0001);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_timestamp(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_TIMESTAMP,
+								0x80C0FFEE);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.avtp_time) == 0x80C0FFEE);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_data_len(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_STREAM_DATA_LEN,
+									0xAAAA);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.packet_info) == 0xAAAA0000);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+}
+
+static void ieciidc_set_field_gv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_GV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00020000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_gateway_info(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_GATEWAY_INFO,
+								0x80C0FFEE);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(ntohl(pdu.format_specific) == 0x80C0FFEE);
+	assert_true(pdu.packet_info == 0);
+}
+
+static void ieciidc_set_field_tag(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_TAG, 2);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(ntohl(pdu.packet_info) == 0x00008000);
+}
+
+static void ieciidc_set_field_channel(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_CHANNEL, 42);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(ntohl(pdu.packet_info) == 0x00002A00);
+}
+
+static void ieciidc_set_field_tcode(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_TCODE, 10);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(ntohl(pdu.packet_info) == 0x000000A0);
+}
+
+static void ieciidc_set_field_sy(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_set(&pdu, AVTP_IECIIDC_FIELD_SY, 10);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu.subtype_data == 0);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(ntohl(pdu.packet_info) == 0x0000000A);
+}
+
+static void ieciidc_set_field_qi_1(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_QI_1, 2);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(ntohl(pay->cip_1) == 0x80000000);
+	assert_true(pay->cip_2 == 0);
+}
+
+static void ieciidc_set_field_qi_2(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_QI_2, 2);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x80000000);
+}
+
+static void ieciidc_set_field_sid(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_SID, 42);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(ntohl(pay->cip_1) == 0x2A000000);
+	assert_true(pay->cip_2 == 0);
+}
+
+static void ieciidc_set_field_dbs(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_DBS, 0xAA);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(ntohl(pay->cip_1) == 0x00AA0000);
+	assert_true(pay->cip_2 == 0);
+}
+
+static void ieciidc_set_field_fn(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_FN, 2);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(ntohl(pay->cip_1) == 0x00008000);
+	assert_true(pay->cip_2 == 0);
+}
+
+static void ieciidc_set_field_qpc(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_QPC, 5);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(ntohl(pay->cip_1) == 0x00002800);
+	assert_true(pay->cip_2 == 0);
+}
+
+static void ieciidc_set_field_sph(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_SPH, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(ntohl(pay->cip_1) == 0x00000400);
+	assert_true(pay->cip_2 == 0);
+}
+
+static void ieciidc_set_field_dbc(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_DBC, 0xAA);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(ntohl(pay->cip_1) == 0x000000AA);
+	assert_true(pay->cip_2 == 0);
+}
+
+static void ieciidc_set_field_fmt(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_FMT, 42);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x2A000000);
+}
+
+static void ieciidc_set_field_syt(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_SYT, 0xAAAA);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x0000AAAA);
+}
+
+static void ieciidc_set_field_tsf(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_TSF, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x00800000);
+}
+
+static void ieciidc_set_field_evt(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_EVT, 2);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x00200000);
+}
+
+static void ieciidc_set_field_sfc(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_SFC, 5);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x00050000);
+}
+
+static void ieciidc_set_field_n(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_N, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x00080000);
+}
+
+static void ieciidc_set_field_nd(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_ND, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x00800000);
+}
+
+static void ieciidc_set_field_no_data(void **state)
+{
+	int res;
+	struct avtp_stream_pdu *pdu = alloca(IECIIDC_PDU_HEADER_SIZE);
+	struct avtp_ieciidc_cip_payload *pay =
+			(struct avtp_ieciidc_cip_payload *) &pdu->avtp_payload;
+
+	memset(pdu, 0, IECIIDC_PDU_HEADER_SIZE);
+
+	res = avtp_ieciidc_pdu_set(pdu, AVTP_IECIIDC_FIELD_CIP_NO_DATA, 0xFF);
+
+	assert_int_equal(res, 0);
+	assert_true(pdu->subtype_data == 0);
+	assert_true(pdu->stream_id == 0);
+	assert_true(pdu->avtp_time == 0);
+	assert_true(pdu->format_specific == 0);
+	assert_true(pdu->packet_info == 0);
+	assert_true(pay->cip_1 == 0);
+	assert_true(ntohl(pay->cip_2) == 0x00FF0000);
+}
+
+static void ieciidc_pdu_init_null_pdu(void **state)
+{
+	int res;
+
+	res = avtp_ieciidc_pdu_init(NULL, 0);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void ieciidc_pdu_init_invalid_tag(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_ieciidc_pdu_init(&pdu, 0x02);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void ieciidc_pdu_init(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu;
+
+	res = avtp_ieciidc_pdu_init(&pdu, 0x01);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00800000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(ntohl(pdu.packet_info) == 0x000040A0);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(ieciidc_get_field_null_pdu),
+		cmocka_unit_test(ieciidc_get_field_null_val),
+		cmocka_unit_test(ieciidc_get_field_invalid_field),
+		cmocka_unit_test(ieciidc_get_field_sv),
+		cmocka_unit_test(ieciidc_get_field_mr),
+		cmocka_unit_test(ieciidc_get_field_tv),
+		cmocka_unit_test(ieciidc_get_field_seq_num),
+		cmocka_unit_test(ieciidc_get_field_tu),
+		cmocka_unit_test(ieciidc_get_field_stream_id),
+		cmocka_unit_test(ieciidc_get_field_timestamp),
+		cmocka_unit_test(ieciidc_get_field_data_len),
+		cmocka_unit_test(ieciidc_get_field_gv),
+		cmocka_unit_test(ieciidc_get_field_gateway_info),
+		cmocka_unit_test(ieciidc_get_field_tag),
+		cmocka_unit_test(ieciidc_get_field_channel),
+		cmocka_unit_test(ieciidc_get_field_tcode),
+		cmocka_unit_test(ieciidc_get_field_sy),
+		cmocka_unit_test(ieciidc_get_field_qi_1),
+		cmocka_unit_test(ieciidc_get_field_qi_2),
+		cmocka_unit_test(ieciidc_get_field_sid),
+		cmocka_unit_test(ieciidc_get_field_dbs),
+		cmocka_unit_test(ieciidc_get_field_fn),
+		cmocka_unit_test(ieciidc_get_field_qpc),
+		cmocka_unit_test(ieciidc_get_field_sph),
+		cmocka_unit_test(ieciidc_get_field_dbc),
+		cmocka_unit_test(ieciidc_get_field_fmt),
+		cmocka_unit_test(ieciidc_get_field_syt),
+		cmocka_unit_test(ieciidc_get_field_tsf),
+		cmocka_unit_test(ieciidc_get_field_evt),
+		cmocka_unit_test(ieciidc_get_field_sfc),
+		cmocka_unit_test(ieciidc_get_field_n),
+		cmocka_unit_test(ieciidc_get_field_nd),
+		cmocka_unit_test(ieciidc_get_field_no_data),
+		cmocka_unit_test(ieciidc_set_field_null_pdu),
+		cmocka_unit_test(ieciidc_set_field_invalid_field),
+		cmocka_unit_test(ieciidc_set_field_sv),
+		cmocka_unit_test(ieciidc_set_field_mr),
+		cmocka_unit_test(ieciidc_set_field_tv),
+		cmocka_unit_test(ieciidc_set_field_seq_num),
+		cmocka_unit_test(ieciidc_set_field_tu),
+		cmocka_unit_test(ieciidc_set_field_stream_id),
+		cmocka_unit_test(ieciidc_set_field_timestamp),
+		cmocka_unit_test(ieciidc_set_field_data_len),
+		cmocka_unit_test(ieciidc_set_field_gv),
+		cmocka_unit_test(ieciidc_set_field_gateway_info),
+		cmocka_unit_test(ieciidc_set_field_tag),
+		cmocka_unit_test(ieciidc_set_field_channel),
+		cmocka_unit_test(ieciidc_set_field_tcode),
+		cmocka_unit_test(ieciidc_set_field_sy),
+		cmocka_unit_test(ieciidc_set_field_qi_1),
+		cmocka_unit_test(ieciidc_set_field_qi_2),
+		cmocka_unit_test(ieciidc_set_field_sid),
+		cmocka_unit_test(ieciidc_set_field_dbs),
+		cmocka_unit_test(ieciidc_set_field_fn),
+		cmocka_unit_test(ieciidc_set_field_qpc),
+		cmocka_unit_test(ieciidc_set_field_sph),
+		cmocka_unit_test(ieciidc_set_field_dbc),
+		cmocka_unit_test(ieciidc_set_field_fmt),
+		cmocka_unit_test(ieciidc_set_field_syt),
+		cmocka_unit_test(ieciidc_set_field_tsf),
+		cmocka_unit_test(ieciidc_set_field_evt),
+		cmocka_unit_test(ieciidc_set_field_sfc),
+		cmocka_unit_test(ieciidc_set_field_n),
+		cmocka_unit_test(ieciidc_set_field_nd),
+		cmocka_unit_test(ieciidc_set_field_no_data),
+		cmocka_unit_test(ieciidc_pdu_init_null_pdu),
+		cmocka_unit_test(ieciidc_pdu_init_invalid_tag),
+		cmocka_unit_test(ieciidc_pdu_init),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
IEC 61883/IIDC support for libavtp

IEC 61883/IIDC is one of the video formats defined by AVTP (IEEE 1722-2016 chapter 5). This pull request adds support to it, and even though there was a focus on IEC 61883-4 (MPEG-TS encapsulation), this patch set should cover all of AVTP IEC 61883 needs.

For simplicity, the "namespace" chosen for IEC 61883/IIDC throughout the code is "avtp_ieciidc".

Naturally, this PR builds on top of what is already available on libavtp, such as common code for packetization and examples.

This PR also adds unit tests for IEC 61883/IIDC, and examples for an MPEG-TS talker and listener.

For more information about each patch, check the patch commit message.

Overall code coverage details are:
lines......: 98.6% (2411 of 2445 lines)
functions..: 100.0% (231 of 231 functions)

Let me know of any questions,