### PR TITLE
build: Fix URL in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,7 @@ pkg.generate(
 	name: 'avtp',
 	description: 'AVTP packetization library',
 	version: meson.project_version(),
-	url: 'github.com/AVnu/OpenAvnu',
+	url: 'github.com/AVnu/libavtp',
 	libraries: avtp_lib,
 )
 


### PR DESCRIPTION
Some time ago we moved libavtp project out of OpenAvnu repo to its own
repo, but missed to update the URL in meson.build. This patch updates
the URL accordingly.

Signed-off-by: Andre Guedes <andre.guedes@intel.com>