### PR TITLE
build: Update version to MAJOR.MINOR.PATCH format

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'libavtp',
 	'c',
-	version: '0.1',
+	version: '0.1.0',
 	license: 'BSD-3-Clause',
 )
 


### PR DESCRIPTION
In meson.build, we have the 'version' argument from project() in the
format MAJOR.MINOR. This patch changes it so it explicitly shows the
PATCH version, following the format MAJOR.MINOR.PATCH.

Signed-off-by: Andre Guedes <andre.guedes@intel.com>