### PR TITLE
Make it possible to build as a meson subproject and make cmoka an optionnal dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,11 @@ avtp_lib = library(
 	install: true,
 )
 
+avtp_dep = declare_dependency(
+	link_with: avtp_lib,
+	include_directories: include_directories('include'),
+)
+
 install_headers(
 	'include/avtp.h',
 	'include/avtp_aaf.h',

--- a/meson.build
+++ b/meson.build
@@ -42,67 +42,75 @@ pkg.generate(
 	libraries: avtp_lib,
 )
 
-test_avtp = executable(
-	'test-avtp',
-	'unit/test-avtp.c',
-	include_directories: include_directories('include'),
-	link_with: avtp_lib,
-	dependencies: dependency('cmocka'),
-	build_by_default: false,
-)
+if get_option('tests') == 'disabled'
+	cmocka = disabler()
+else
+	cmocka = dependency('cmocka', required: get_option('tests') == 'enabled')
+endif
 
-test_aaf = executable(
-	'test-aaf',
-	'unit/test-aaf.c',
-	include_directories: include_directories('include'),
-	link_with: avtp_lib,
-	dependencies: dependency('cmocka'),
-	build_by_default: false,
-)
+if cmocka.found()
+	test_avtp = executable(
+		'test-avtp',
+		'unit/test-avtp.c',
+		include_directories: include_directories('include'),
+		link_with: avtp_lib,
+		dependencies: cmocka,
+		build_by_default: false,
+	)
 
-test_crf = executable(
-	'test-crf',
-	'unit/test-crf.c',
-	include_directories: include_directories('include'),
-	link_with: avtp_lib,
-	dependencies: dependency('cmocka'),
-	build_by_default: false,
-)
+	test_aaf = executable(
+		'test-aaf',
+		'unit/test-aaf.c',
+		include_directories: include_directories('include'),
+		link_with: avtp_lib,
+		dependencies: cmocka,
+		build_by_default: false,
+	)
 
-test_stream = executable(
-	'test-stream',
-	'unit/test-stream.c',
-	'src/avtp_stream.c',
-	include_directories: include_directories('include', 'src'),
-	link_with: avtp_lib,
-	dependencies: dependency('cmocka'),
-	build_by_default: false,
-)
+	test_crf = executable(
+		'test-crf',
+		'unit/test-crf.c',
+		include_directories: include_directories('include'),
+		link_with: avtp_lib,
+		dependencies: cmocka,
+		build_by_default: false,
+	)
 
-test_cvf = executable(
-	'test-cvf',
-	'unit/test-cvf.c',
-	include_directories: include_directories('include'),
-	link_with: avtp_lib,
-	dependencies: dependency('cmocka'),
-	build_by_default: false,
-)
+	test_stream = executable(
+		'test-stream',
+		'unit/test-stream.c',
+		'src/avtp_stream.c',
+		include_directories: include_directories('include', 'src'),
+		link_with: avtp_lib,
+		dependencies: cmocka,
+		build_by_default: false,
+	)
 
-test_ieciidc = executable(
-	'test-ieciidc',
-	'unit/test-ieciidc.c',
-	include_directories: include_directories('include'),
-	link_with: avtp_lib,
-	dependencies: dependency('cmocka'),
-	build_by_default: false,
-)
+	test_cvf = executable(
+		'test-cvf',
+		'unit/test-cvf.c',
+		include_directories: include_directories('include'),
+		link_with: avtp_lib,
+		dependencies: cmocka,
+		build_by_default: false,
+	)
 
-test('AVTP API', test_avtp)
-test('Stream API', test_stream)
-test('AAF API', test_aaf)
-test('CRF API', test_crf)
-test('CVF API', test_cvf)
-test('IEC61883/IIDC API', test_ieciidc)
+	test_ieciidc = executable(
+		'test-ieciidc',
+		'unit/test-ieciidc.c',
+		include_directories: include_directories('include'),
+		link_with: avtp_lib,
+		dependencies: cmocka,
+		build_by_default: false,
+	)
+
+	test('AVTP API', test_avtp)
+	test('Stream API', test_stream)
+	test('AAF API', test_aaf)
+	test('CRF API', test_crf)
+	test('CVF API', test_cvf)
+	test('IEC61883/IIDC API', test_ieciidc)
+endif
 
 cc = meson.get_compiler('c')
 mdep = cc.find_library('m', required : false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,7 @@
+# Port to 'feature' once we depend on meson 0.47.0
+option(
+    'tests',
+    type : 'combo',
+    value : 'auto',
+    choices : ['enabled', 'disabled', 'auto'],
+    description : 'Build unit test libraries')


### PR DESCRIPTION
This adds a meson option to allow disabling tests.