### PR TITLE
Fix compilation with GCC 9

### DIFF
--- a/src/avtp_aaf.c
+++ b/src/avtp_aaf.c
@@ -131,8 +131,9 @@ int avtp_aaf_pdu_get(const struct avtp_stream_pdu *pdu,
 static int set_field_value(struct avtp_stream_pdu *pdu,
 				enum avtp_aaf_field field, uint32_t val)
 {
-	uint32_t *ptr, bitmap, mask;
+	uint32_t bitmap, mask;
 	uint8_t shift;
+	void *ptr;
 
 	switch (field) {
 	case AVTP_AAF_FIELD_FORMAT:
@@ -169,11 +170,11 @@ static int set_field_value(struct avtp_stream_pdu *pdu,
 		return -EINVAL;
 	}
 
-	bitmap = ntohl(*ptr);
+	bitmap = get_unaligned_be32(ptr);
 
 	BITMAP_SET_VALUE(bitmap, val, mask, shift);
 
-	*ptr = htonl(bitmap);
+	put_unaligned_be32(bitmap, ptr);
 
 	return 0;
 }

--- a/src/avtp_cvf.c
+++ b/src/avtp_cvf.c
@@ -133,8 +133,9 @@ int avtp_cvf_pdu_get(const struct avtp_stream_pdu *pdu,
 static int set_field_value(struct avtp_stream_pdu *pdu,
 				enum avtp_cvf_field field, uint32_t val)
 {
-	uint32_t *ptr, bitmap, mask;
+	uint32_t bitmap, mask;
 	uint8_t shift;
+	void *ptr;
 
 	switch (field) {
 	case AVTP_CVF_FIELD_FORMAT:
@@ -166,11 +167,11 @@ static int set_field_value(struct avtp_stream_pdu *pdu,
 		return -EINVAL;
 	}
 
-	bitmap = ntohl(*ptr);
+	bitmap = get_unaligned_be32(ptr);
 
 	BITMAP_SET_VALUE(bitmap, val, mask, shift);
 
-	*ptr = htonl(bitmap);
+	put_unaligned_be32(bitmap, ptr);
 
 	return 0;
 }

--- a/src/avtp_ieciidc.c
+++ b/src/avtp_ieciidc.c
@@ -258,8 +258,9 @@ int avtp_ieciidc_pdu_get(const struct avtp_stream_pdu *pdu,
 static int set_field_value(struct avtp_stream_pdu *pdu,
 			enum avtp_ieciidc_field field, uint64_t value)
 {
-	uint32_t *ptr, bitmap, mask;
+	uint32_t bitmap, mask;
 	uint8_t shift;
+	void *ptr;
 
 	struct avtp_ieciidc_cip_payload *pay =
 			(struct avtp_ieciidc_cip_payload *) pdu->avtp_payload;
@@ -374,11 +375,11 @@ static int set_field_value(struct avtp_stream_pdu *pdu,
 		return -EINVAL;
 	}
 
-	bitmap = ntohl(*ptr);
+	bitmap = get_unaligned_be32(ptr);
 
 	BITMAP_SET_VALUE(bitmap, value, mask, shift);
 
-	*ptr = htonl(bitmap);
+	put_unaligned_be32(bitmap, ptr);
 
 	return 0;
 }

--- a/src/avtp_stream.c
+++ b/src/avtp_stream.c
@@ -126,8 +126,9 @@ int avtp_stream_pdu_get(const struct avtp_stream_pdu *pdu,
 static int set_field_value(struct avtp_stream_pdu *pdu,
 				enum avtp_stream_field field, uint64_t val)
 {
-	uint32_t *ptr, bitmap, mask;
+	uint32_t bitmap, mask;
 	uint8_t shift;
+	void *ptr;
 
 	switch (field) {
 	case AVTP_STREAM_FIELD_SV:
@@ -164,11 +165,11 @@ static int set_field_value(struct avtp_stream_pdu *pdu,
 		return -EINVAL;
 	}
 
-	bitmap = ntohl(*ptr);
+	bitmap = get_unaligned_be32(ptr);
 
 	BITMAP_SET_VALUE(bitmap, val, mask, shift);
 
-	*ptr = htonl(bitmap);
+	put_unaligned_be32(bitmap, ptr);
 
 	return 0;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -43,3 +43,17 @@
  */
 #define BITMAP_SET_VALUE(bitmap, val, mask, shift) \
 			(bitmap = (bitmap & ~mask) | ((val << shift) & mask))
+
+struct __una_u32 { uint32_t x; } __attribute__((packed));
+
+static inline uint32_t get_unaligned_be32(const void *p)
+{
+	const struct __una_u32 *ptr = (const struct __una_u32 *)p;
+	return ntohl(ptr->x);
+}
+
+static inline void put_unaligned_be32(uint32_t val, void *p)
+{
+	struct __una_u32 *ptr = (struct __una_u32 *)p;
+	ptr->x = htonl(val);
+}


### PR DESCRIPTION
GCC 9 complains about the usage of unaligned access, the solution is
add helpers that provide safe unaligned pointer access.

As all AVTP unaligned access deal with 32-bit Big Endian fields, the
helpers also convert those values to/from the native CPU
representation.

The code is based on code from the Linux kernel:

   tools/include/linux/unaligned/packed_struct.h

Signed-off-by: Vinicius Costa Gomes <vinicius.gomes@intel.com>