### PR TITLE
examples: Fix imprecise commentary

### DIFF
--- a/examples/crf-listener.c
+++ b/examples/crf-listener.c
@@ -628,10 +628,8 @@ static int recover_mclk(struct avtp_crf_pdu *pdu)
 	int res, idx;
 	uint64_t ts_mclk, ts_crf;
 
-	/* To recover the media clock we consider only the first timestamp from
-	 * CRF PDU since the others timestamps are incremented monotonically
-	 * from the first timestamp (see Section 10.7 from IEEE 1722-2016
-	 * spec).
+	/* For simplicity's sake, we consider only the first timestamp from
+	 * CRF PDU to recover the media clock.
 	 */
 	ts_crf = be64toh(pdu->crf_data[0]);
 


### PR DESCRIPTION
Multiple timestamps on a CRF PDU are meant to speed up Listener locking
its media clock to the supplied clock. While the extra timestamps can be
ignored in certain circumstances, it's not due them being "monotonically
increasing".

This is done just to keep it simple.