### PR TITLE
build: Update version to 0.2.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'libavtp',
 	'c',
-	version: '0.1.0',
+	version: '0.2.0',
 	license: 'BSD-3-Clause',
 	meson_version: '>=0.46.0',
 )


### PR DESCRIPTION
Since 0.1.0, libavtp had some nice improvements:

 - cmoka is now a test dependency only
 - Fixed issues with gcc 9
 - RVF support.

So it makes sense to bump the version.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>