### PR TITLE
Fixed Linux/Alpine 3.20 build

### DIFF
--- a/src/avtp_rvf.c
+++ b/src/avtp_rvf.c
@@ -27,6 +27,7 @@
  */
 
 #include <arpa/inet.h>
+#include <endian.h>
 #include <string.h>
 
 #include "avtp.h"

--- a/src/avtp_stream.c
+++ b/src/avtp_stream.c
@@ -26,6 +26,7 @@
  */
 
 #include <arpa/inet.h>
+#include <endian.h>
 #include <stddef.h>
 
 #include "avtp.h"


### PR DESCRIPTION
I noticed the error while compiling GStreamer 1.24.5 on Alpine/Linux 3.20:
```
[1352/8486] Linking target subprojects/libavtp/libavtp.so.0.2.0
ninja: job failed: cc  -o subprojects/libavtp/libavtp.so.0.2.0 subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp.c.o subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_aaf.c.o subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_crf.c.o subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_cvf.c.o subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_rvf.c.o subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_ieciidc.c.o subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_stream.c.o -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,-soname,libavtp.so.0
/usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_rvf.c.o: in function `avtp_rvf_pdu_get':
/app/gstreamer/builddir/../subprojects/libavtp/src/avtp_rvf.c:209:(.text+0x47c): undefined reference to `be64toh'
/usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_rvf.c.o: in function `set_raw_field_value':
/app/gstreamer/builddir/../subprojects/libavtp/src/avtp_rvf.c:320:(.text+0x804): undefined reference to `be64toh'
/usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: /app/gstreamer/builddir/../subprojects/libavtp/src/avtp_rvf.c:324:(.text+0x840): undefined reference to `htobe64'
/usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_stream.c.o: in function `avtp_stream_pdu_get':
/app/gstreamer/builddir/../subprojects/libavtp/src/avtp_stream.c:116:(.text+0x2b8): undefined reference to `be64toh'
/usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: subprojects/libavtp/libavtp.so.0.2.0.p/src_avtp_stream.c.o: in function `avtp_stream_pdu_set':
/app/gstreamer/builddir/../subprojects/libavtp/src/avtp_stream.c:199:(.text+0x524): undefined reference to `htobe64'
collect2: error: ld returned 1 exit status
ninja: subcommand failed
```